### PR TITLE
Add new instrumentations : changes in tabMorph & scrolling

### DIFF
--- a/DebuggingSpy-Tests/DSRecordHistoryTest.class.st
+++ b/DebuggingSpy-Tests/DSRecordHistoryTest.class.st
@@ -296,6 +296,55 @@ DSRecordHistoryTest >> testBuildWindows [
 ]
 
 { #category : 'tests' }
+DSRecordHistoryTest >> testCollectScrollingPeriods [
+
+	| scrollList |
+	history records: {
+			(DSMouseEnterWindowRecord new
+				 dateTime: '2026-03-25T10:01:17' asDateAndTime;
+				 windowId: 1).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:02:44' asDateAndTime;
+				 windowId: 1).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:06:08' asDateAndTime;
+				 windowId: 1).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:09:23' asDateAndTime;
+				 windowId: 1).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:13:41' asDateAndTime;
+				 windowId: 1).
+			(DSMouseLeaveWindowRecord new
+				 dateTime: '2026-03-25T10:20:16' asDateAndTime;
+				 windowId: 1).
+			(DSMouseEnterWindowRecord new
+				 dateTime: '2026-03-25T10:21:41' asDateAndTime;
+				 windowId: 2).
+			(DSDoItRecord new
+				 dateTime: '2026-03-25T10:26:09' asDateAndTime;
+				 windowId: 2).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:13:41' asDateAndTime;
+				 windowId: 2).
+			(DSStepIntoRecord new
+				 dateTime: '2026-03-25T10:14:01' asDateAndTime;
+				 windowId: 2) }.
+
+	scrollList := history collectScrollingPeriods.
+
+	self assert: scrollList size equals: 2.
+	self assert: scrollList first key equals: {
+			'2026-03-25T10:02:44' asDateAndTime.
+			'2026-03-25T10:13:41' asDateAndTime }.
+	self assert: scrollList first value equals: 1.
+	self assert: scrollList second key equals: {
+			'2026-03-25T10:13:41' asDateAndTime.
+			'2026-03-25T10:13:41' asDateAndTime }.
+	self assert: scrollList second value equals: 2
+]
+
+{ #category : 'tests' }
 DSRecordHistoryTest >> testCollectTimeDiscrepancies [
 
 	| deltaDict |
@@ -636,6 +685,56 @@ DSRecordHistoryTest >> testFixWindowRecordKeysNames [
 	self assert: (windowsHistory keys detect: [ :k | k windowId = 1 ]) windowName equals: 'playGroundWindow'.
 	self assert: (windowsHistory keys detect: [ :k | k windowId = 53 ]) windowName equals: 'browserWindow'.
 	self assert: (windowsHistory keys detect: [ :k | k windowId = 2 ]) windowName isNil
+]
+
+{ #category : 'tests' }
+DSRecordHistoryTest >> testGetSumOfScrollingPeriods [
+
+	| scrollList |
+	history records: {
+			(DSMouseEnterWindowRecord new
+				 dateTime: '2026-03-25T10:01:17' asDateAndTime;
+				 windowId: 1).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:02:44' asDateAndTime;
+				 windowId: 1).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:06:08' asDateAndTime;
+				 windowId: 1).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:09:23' asDateAndTime;
+				 windowId: 1).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:13:41' asDateAndTime;
+				 windowId: 1).
+			(DSMouseLeaveWindowRecord new
+				 dateTime: '2026-03-25T10:20:16' asDateAndTime;
+				 windowId: 1).
+			(DSMouseEnterWindowRecord new
+				 dateTime: '2026-03-25T10:21:41' asDateAndTime;
+				 windowId: 2).
+			(DSDoItRecord new
+				 dateTime: '2026-03-25T10:26:09' asDateAndTime;
+				 windowId: 2).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:13:41' asDateAndTime;
+				 windowId: 2).
+			(DSStepIntoRecord new
+				 dateTime: '2026-03-25T10:14:01' asDateAndTime;
+				 windowId: 2).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:26:35' asDateAndTime;
+				 windowId: 1).
+			(DSScrollingRecord new
+				 dateTime: '2026-03-25T10:27:39' asDateAndTime;
+				 windowId: 1) }.
+
+
+	scrollList := history getSumOfScrollingPeriods.
+
+	self assert: scrollList size equals: 2.
+	self assert: (scrollList at: 1) equals: (Duration seconds: 721).
+	self assert: (scrollList at: 2) equals: (Duration seconds: 0)
 ]
 
 { #category : 'tests' }

--- a/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
+++ b/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
@@ -739,7 +739,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeBrowse [
 	codePresenter rawSelection: (1 to: 4).
 	browseCommand execute.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 4.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSBrowseRecord.

--- a/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
+++ b/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
@@ -408,7 +408,7 @@ DSSpyInstrumenterTest >> testInstrumentClyTextEditorInspectIt [
 	clyEditor := self clyTextEditor.
 	clyEditor inspectIt.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -658,7 +658,7 @@ DSSpyInstrumenterTest >> testInstrumentRubEditorInspectIt [
 	rubEditor selectAll.
 	rubEditor inspectIt.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -721,7 +721,7 @@ DSSpyInstrumenterTest >> testInstrumentSendersAction [
 	rubEditor := self rubSmalltalkEditor.
 	rubEditor sendersOf: #testInstrumentHaltHits.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSImplementorsRecord.
@@ -739,7 +739,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeBrowse [
 	codePresenter rawSelection: (1 to: 4).
 	browseCommand execute.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 6.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSBrowseRecord.
@@ -835,13 +835,16 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeImplementors [
 	codePresenter selectionInterval: (1 to: 7).
 	browseCommand execute.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSImplementorsRecord.
 	self assert: record windowId equals: codePresenter window identityHash.
-
+	
 	record := self registry second.
+	self assert: record class identicalTo: DSMorphTabRecord.
+
+	record := self registry third.
 	self assert: record class identicalTo: DSWindowOpenedRecord
 ]
 
@@ -856,7 +859,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeInspectIt [
 	codePresenter rawSelection: (1 to: 4).
 	inspectItCommand execute.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -890,13 +893,16 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeSenders [
 	codePresenter selectionInterval: (1 to: 7).
 	browseCommand execute.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSSendersRecord.
 	self assert: record windowId equals: codePresenter window identityHash.
 
 	record := self registry second.
+	self assert: record class identicalTo: DSMorphTabRecord.
+	
+	record := self registry third.
 	self assert: record class identicalTo: DSWindowOpenedRecord
 ]
 

--- a/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
+++ b/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
@@ -408,7 +408,7 @@ DSSpyInstrumenterTest >> testInstrumentClyTextEditorInspectIt [
 	clyEditor := self clyTextEditor.
 	clyEditor inspectIt.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -658,7 +658,7 @@ DSSpyInstrumenterTest >> testInstrumentRubEditorInspectIt [
 	rubEditor selectAll.
 	rubEditor inspectIt.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -721,7 +721,7 @@ DSSpyInstrumenterTest >> testInstrumentSendersAction [
 	rubEditor := self rubSmalltalkEditor.
 	rubEditor sendersOf: #testInstrumentHaltHits.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSImplementorsRecord.
@@ -739,7 +739,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeBrowse [
 	codePresenter rawSelection: (1 to: 4).
 	browseCommand execute.
 
-	self assert: self registry size equals: 6.
+	self assert: self registry size equals: 2.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSBrowseRecord.
@@ -835,16 +835,13 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeImplementors [
 	codePresenter selectionInterval: (1 to: 7).
 	browseCommand execute.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSImplementorsRecord.
 	self assert: record windowId equals: codePresenter window identityHash.
 	
 	record := self registry second.
-	self assert: record class identicalTo: DSMorphTabRecord.
-
-	record := self registry third.
 	self assert: record class identicalTo: DSWindowOpenedRecord
 ]
 
@@ -859,7 +856,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeInspectIt [
 	codePresenter rawSelection: (1 to: 4).
 	inspectItCommand execute.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -893,16 +890,13 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeSenders [
 	codePresenter selectionInterval: (1 to: 7).
 	browseCommand execute.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSSendersRecord.
 	self assert: record windowId equals: codePresenter window identityHash.
-
-	record := self registry second.
-	self assert: record class identicalTo: DSMorphTabRecord.
 	
-	record := self registry third.
+	record := self registry second.
 	self assert: record class identicalTo: DSWindowOpenedRecord
 ]
 

--- a/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
+++ b/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
@@ -408,7 +408,7 @@ DSSpyInstrumenterTest >> testInstrumentClyTextEditorInspectIt [
 	clyEditor := self clyTextEditor.
 	clyEditor inspectIt.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -658,7 +658,7 @@ DSSpyInstrumenterTest >> testInstrumentRubEditorInspectIt [
 	rubEditor selectAll.
 	rubEditor inspectIt.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -721,7 +721,7 @@ DSSpyInstrumenterTest >> testInstrumentSendersAction [
 	rubEditor := self rubSmalltalkEditor.
 	rubEditor sendersOf: #testInstrumentHaltHits.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSImplementorsRecord.
@@ -739,7 +739,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeBrowse [
 	codePresenter rawSelection: (1 to: 4).
 	browseCommand execute.
 
-	self assert: self registry size equals: 4.
+	self assert: self registry size equals: 6.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSBrowseRecord.
@@ -835,13 +835,16 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeImplementors [
 	codePresenter selectionInterval: (1 to: 7).
 	browseCommand execute.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSImplementorsRecord.
 	self assert: record windowId equals: codePresenter window identityHash.
 	
 	record := self registry second.
+	self assert: record class identicalTo: DSMorphTabRecord.
+
+	record := self registry third.
 	self assert: record class identicalTo: DSWindowOpenedRecord
 ]
 
@@ -856,7 +859,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeInspectIt [
 	codePresenter rawSelection: (1 to: 4).
 	inspectItCommand execute.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -890,13 +893,16 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeSenders [
 	codePresenter selectionInterval: (1 to: 7).
 	browseCommand execute.
 
-	self assert: self registry size equals: 2.
+	self assert: self registry size equals: 3.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSSendersRecord.
 	self assert: record windowId equals: codePresenter window identityHash.
 	
 	record := self registry second.
+	self assert: record class identicalTo: DSMorphTabRecord.
+	
+	record := self registry third.
 	self assert: record class identicalTo: DSWindowOpenedRecord
 ]
 

--- a/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
+++ b/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
@@ -408,7 +408,7 @@ DSSpyInstrumenterTest >> testInstrumentClyTextEditorInspectIt [
 	clyEditor := self clyTextEditor.
 	clyEditor inspectIt.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -658,7 +658,7 @@ DSSpyInstrumenterTest >> testInstrumentRubEditorInspectIt [
 	rubEditor selectAll.
 	rubEditor inspectIt.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -721,7 +721,7 @@ DSSpyInstrumenterTest >> testInstrumentSendersAction [
 	rubEditor := self rubSmalltalkEditor.
 	rubEditor sendersOf: #testInstrumentHaltHits.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSImplementorsRecord.
@@ -739,7 +739,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeBrowse [
 	codePresenter rawSelection: (1 to: 4).
 	browseCommand execute.
 
-	self assert: self registry size equals: 6.
+	self assert: self registry size equals: 2.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSBrowseRecord.
@@ -835,16 +835,13 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeImplementors [
 	codePresenter selectionInterval: (1 to: 7).
 	browseCommand execute.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSImplementorsRecord.
 	self assert: record windowId equals: codePresenter window identityHash.
 	
 	record := self registry second.
-	self assert: record class identicalTo: DSMorphTabRecord.
-
-	record := self registry third.
 	self assert: record class identicalTo: DSWindowOpenedRecord
 ]
 
@@ -859,7 +856,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeInspectIt [
 	codePresenter rawSelection: (1 to: 4).
 	inspectItCommand execute.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 	record := self registry first.
 
 	self assert: record class identicalTo: DSInspectItRecord.
@@ -893,7 +890,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeSenders [
 	codePresenter selectionInterval: (1 to: 7).
 	browseCommand execute.
 
-	self assert: self registry size equals: 3.
+	self assert: self registry size equals: 2.
 
 	record := self registry first.
 	self assert: record class identicalTo: DSSendersRecord.
@@ -902,7 +899,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeSenders [
 	record := self registry second.
 	self assert: record class identicalTo: DSMorphTabRecord.
 	
-	record := self registry third.
+	record := self registry second.
 	self assert: record class identicalTo: DSWindowOpenedRecord
 ]
 

--- a/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
+++ b/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
@@ -897,9 +897,6 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeSenders [
 	self assert: record windowId equals: codePresenter window identityHash.
 	
 	record := self registry second.
-	self assert: record class identicalTo: DSMorphTabRecord.
-	
-	record := self registry second.
 	self assert: record class identicalTo: DSWindowOpenedRecord
 ]
 

--- a/DebuggingSpy/ClyShowMessageImplementorCommand.extension.st
+++ b/DebuggingSpy/ClyShowMessageImplementorCommand.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'ClyShowMessageImplementorCommand' }
+
+{ #category : '*DebuggingSpy' }
+ClyShowMessageImplementorCommand >> recordWindow [
+
+	^ browser
+]

--- a/DebuggingSpy/ClyShowMessageSenderCommand.extension.st
+++ b/DebuggingSpy/ClyShowMessageSenderCommand.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'ClyShowMessageSenderCommand' }
+
+{ #category : '*DebuggingSpy' }
+ClyShowMessageSenderCommand >> recordWindow [
+
+	^ browser
+]

--- a/DebuggingSpy/DSAbstractHaltRecord.class.st
+++ b/DebuggingSpy/DSAbstractHaltRecord.class.st
@@ -29,7 +29,8 @@ DSAbstractHaltRecord >> method: aMethod [
 DSAbstractHaltRecord >> record: anRBProgramNode [
 
 	method := anRBProgramNode methodNode compiledMethod name.
-	sourceCodeInterval := anRBProgramNode start to: anRBProgramNode stop
+	sourceCodeInterval := anRBProgramNode start to: anRBProgramNode stop.
+	super record: anRBProgramNode
 ]
 
 { #category : 'accessing' }

--- a/DebuggingSpy/DSCodeActionRecord.class.st
+++ b/DebuggingSpy/DSCodeActionRecord.class.st
@@ -18,8 +18,9 @@ DSCodeActionRecord >> record: anEditor [
 
 	selectedString := DSSpy recordSourceCode
 		                  ifTrue: [ anEditor recordSelectedString ]
-		                  ifFalse: [ 
-		                  DSSpy recordSourceCodeDisabledErrorMessage ]
+		                  ifFalse: [ DSSpy recordSourceCodeDisabledErrorMessage ].
+
+	super record: anEditor
 ]
 
 { #category : 'accessing' }

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -12,14 +12,13 @@ Class {
 	#tag : 'Records'
 }
 
-{ #category : 'accessing' }
-DSMorphTabRecord class >> link [ 
+{ #category : 'instance creation' }
+DSMorphTabRecord class >> for: anObject [
 
-	^ DSMetaLink new
-		  metaObject: self;
-		  selector: #for:;
-		  arguments: #( arguments );
-		  control: #before
+	| rec |
+	rec := self new record: anObject.
+	rec ifNotNil: [ DSRecordRegistry current addRecord: rec ].
+	^ rec
 ]
 
 { #category : 'accessing' }
@@ -29,11 +28,12 @@ DSMorphTabRecord >> eventName [
 ]
 
 { #category : 'actions api' }
-DSMorphTabRecord >> record: anArrayOfArguments [
+DSMorphTabRecord >> record: aTabGroupMorph [
 
-	| newTabMorph |
+	| tabTool|
 	
-	newTabMorph := anArrayOfArguments second.
+	tabTool := aTabGroupMorph submorphs first submorphs.
+	tabTool isEmpty ifTrue: [ ^ nil ].
 
-	tabName := newTabMorph asString
+	tabName := tabTool first asString
 ]

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -12,6 +12,16 @@ Class {
 	#tag : 'Records'
 }
 
+{ #category : 'instance creation' }
+DSMorphTabRecord class >> for: aTabMorphSelector [
+
+	| rec |
+	rec := self new record: aTabMorphSelector.
+	rec ifNotNil: [ DSRecordRegistry current addRecord: rec ].
+
+	^ rec
+]
+
 { #category : 'accessing' }
 DSMorphTabRecord >> eventName [
 
@@ -22,8 +32,8 @@ DSMorphTabRecord >> eventName [
 DSMorphTabRecord >> record: aTabMorphSelector [
 
 	| selectedTab |
+	selectedTab := (aTabMorphSelector submorphs select: [ :morph | morph class = TabLabelMorph ]) select: #isSelected.
+	selectedTab ifEmpty: [ ^ nil ].
 
-	selectedTab := ((aTabMorphSelector submorphs select: [:morph | morph class = TabLabelMorph]) select: #isSelected).
-	
-	tabName := selectedTab isEmpty ifTrue: [ nil ] ifFalse: [ selectedTab first asString ]
+	tabName := selectedTab first asString
 ]

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -21,5 +21,5 @@ DSMorphTabRecord >> eventName [
 { #category : 'actions api' }
 DSMorphTabRecord >> record: aTabMorphSelector [
 
-	tabName := (aTabMorphSelector submorphs select: #isSelected) first 
+	tabName := ((aTabMorphSelector submorphs select: [:morph | morph class = TabLabelMorph]) select: #isSelected) first asString
 ]

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -1,0 +1,25 @@
+"
+I am recording the MorphTab in which the user is.
+"
+Class {
+	#name : 'DSMorphTabRecord',
+	#superclass : 'DSAbstractEventRecord',
+	#instVars : [
+		'tabName'
+	],
+	#category : 'DebuggingSpy-Records',
+	#package : 'DebuggingSpy',
+	#tag : 'Records'
+}
+
+{ #category : 'accessing' }
+DSMorphTabRecord >> eventName [
+
+	^ 'Changing in tab'
+]
+
+{ #category : 'actions api' }
+DSMorphTabRecord >> record: aTabMorphSelector [
+
+	tabName := (aTabMorphSelector submorphs select: #isSelected) first 
+]

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -12,14 +12,14 @@ Class {
 	#tag : 'Records'
 }
 
-{ #category : 'instance creation' }
-DSMorphTabRecord class >> for: aTabMorphSelector [
+{ #category : 'accessing' }
+DSMorphTabRecord class >> link [ 
 
-	| rec |
-	rec := self new record: aTabMorphSelector.
-	rec ifNotNil: [ DSRecordRegistry current addRecord: rec ].
-
-	^ rec
+	^ DSMetaLink new
+		  metaObject: self;
+		  selector: #for:;
+		  arguments: #( arguments );
+		  control: #before
 ]
 
 { #category : 'accessing' }
@@ -29,11 +29,11 @@ DSMorphTabRecord >> eventName [
 ]
 
 { #category : 'actions api' }
-DSMorphTabRecord >> record: aTabMorphSelector [
+DSMorphTabRecord >> record: anArrayOfArguments [
 
-	| selectedTab |
-	selectedTab := (aTabMorphSelector submorphs select: [ :morph | morph class = TabLabelMorph ]) select: #isSelected.
-	selectedTab ifEmpty: [ ^ nil ].
+	| newTabMorph |
+	
+	newTabMorph := anArrayOfArguments second.
 
-	tabName := selectedTab first asString
+	tabName := newTabMorph asString
 ]

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -21,5 +21,9 @@ DSMorphTabRecord >> eventName [
 { #category : 'actions api' }
 DSMorphTabRecord >> record: aTabMorphSelector [
 
-	tabName := ((aTabMorphSelector submorphs select: [:morph | morph class = TabLabelMorph]) select: #isSelected) first asString
+	| selectedTab |
+
+	selectedTab := ((aTabMorphSelector submorphs select: [:morph | morph class = TabLabelMorph]) select: #isSelected).
+	
+	tabName := selectedTab isEmpty ifTrue: [ nil ] ifFalse: [ selectedTab first asString ]
 ]

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -12,14 +12,13 @@ Class {
 	#tag : 'Records'
 }
 
-{ #category : 'accessing' }
-DSMorphTabRecord class >> link [ 
+{ #category : 'instance creation' }
+DSMorphTabRecord class >> for: anObject [
 
-	^ DSMetaLink new
-		  metaObject: self;
-		  selector: #for:;
-		  arguments: #( arguments );
-		  control: #before
+	| rec |
+	rec := self new record: anObject.
+	rec ifNotNil: [ DSRecordRegistry current addRecord: rec ].
+	^ rec
 ]
 
 { #category : 'accessing' }

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -36,5 +36,5 @@ DSMorphTabRecord >> record: aTabGroupMorph [
 
 	tabName := tabTool first asString.
 
-	super record: aTabGroupMorph
+	super record: aTabGroupMorph window
 ]

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -30,10 +30,11 @@ DSMorphTabRecord >> eventName [
 { #category : 'actions api' }
 DSMorphTabRecord >> record: aTabGroupMorph [
 
-	| tabTool|
-	
+	| tabTool |
 	tabTool := aTabGroupMorph submorphs first submorphs.
 	tabTool isEmpty ifTrue: [ ^ nil ].
 
-	tabName := tabTool first asString
+	tabName := tabTool first asString.
+
+	super record: aTabGroupMorph
 ]

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -13,11 +13,12 @@ Class {
 }
 
 { #category : 'instance creation' }
-DSMorphTabRecord class >> for: anObject [
+DSMorphTabRecord class >> for: aTabMorphSelector [
 
 	| rec |
-	rec := self new record: anObject.
+	rec := self new record: aTabMorphSelector.
 	rec ifNotNil: [ DSRecordRegistry current addRecord: rec ].
+
 	^ rec
 ]
 

--- a/DebuggingSpy/DSMorphTabRecord.class.st
+++ b/DebuggingSpy/DSMorphTabRecord.class.st
@@ -12,14 +12,14 @@ Class {
 	#tag : 'Records'
 }
 
-{ #category : 'instance creation' }
-DSMorphTabRecord class >> for: aTabMorphSelector [
+{ #category : 'accessing' }
+DSMorphTabRecord class >> link [ 
 
-	| rec |
-	rec := self new record: aTabMorphSelector.
-	rec ifNotNil: [ DSRecordRegistry current addRecord: rec ].
-
-	^ rec
+	^ DSMetaLink new
+		  metaObject: self;
+		  selector: #for:;
+		  arguments: #( arguments );
+		  control: #before
 ]
 
 { #category : 'accessing' }

--- a/DebuggingSpy/DSRecordHistory.class.st
+++ b/DebuggingSpy/DSRecordHistory.class.st
@@ -119,6 +119,30 @@ DSRecordHistory >> buildWindows [
 				                   ((w respondsTo: #type) and: [ #( 'Finish' 'Post-task' 'Survey' ) includes: w type ]) or: [ w windowId = -1 ] ] ]
 ]
 
+{ #category : 'API-history' }
+DSRecordHistory >> collectScrollingPeriods [
+
+	| i scrollingPeriods |
+	i := 1.
+	scrollingPeriods := OrderedCollection new.
+
+	[ i <= records size ] whileTrue: [
+			(records at: i) class = DSScrollingRecord ifTrue: [
+					| start stop |
+					start := (records at: i) dateTime.
+					stop := (records at: i) dateTime.
+					i := i + 1.
+					[ i <= records size and: [ (records at: i) class = DSScrollingRecord ] ] whileTrue: [
+							stop := (records at: i) dateTime.
+							i := i + 1 ].
+					scrollingPeriods add: {
+							start.
+							stop } -> (records at: i - 1) windowId ].
+			i := i + 1 ].
+
+	^ scrollingPeriods
+]
+
 { #category : 'private - history' }
 DSRecordHistory >> collectTimeDiscrepancies [
 	"Returns a dictionary which contains all delta between two records above than 5s"
@@ -337,6 +361,21 @@ DSRecordHistory >> fixWindowRecordKeysNames [
 
 	windowNames keysAndValuesDo: [ :id :name | 
 		(self findWindowRecordKeyForID: id) windowName: name ]
+]
+
+{ #category : 'API-history' }
+DSRecordHistory >> getSumOfScrollingPeriods [
+
+	| scrollingPeriods |
+	scrollingPeriods := self collectScrollingPeriods.
+	scrollingPeriods := scrollingPeriods collect: [ :association |
+		                    association key second - association key first -> association value ].
+
+	scrollingPeriods := scrollingPeriods groupedBy: [ :association | association value ].
+
+	scrollingPeriods := scrollingPeriods collect: [ :array | array collect: [ :association | association key ] ].
+
+	^ scrollingPeriods collect: [ :value | value sum ]
 ]
 
 { #category : 'API-history' }

--- a/DebuggingSpy/DSScrollingRecord.class.st
+++ b/DebuggingSpy/DSScrollingRecord.class.st
@@ -1,0 +1,24 @@
+"
+I am recording events linked to scrolling.
+"
+Class {
+	#name : 'DSScrollingRecord',
+	#superclass : 'DSAbstractEventRecord',
+	#instVars : [
+		'toolName'
+	],
+	#category : 'DebuggingSpy-Records',
+	#package : 'DebuggingSpy',
+	#tag : 'Records'
+}
+
+{ #category : 'accessing' }
+DSScrollingRecord >> eventName [
+	^ 'Scrolling'
+]
+
+{ #category : 'actions api' }
+DSScrollingRecord >> record: aMorph [
+
+	toolName := aMorph asString
+]

--- a/DebuggingSpy/DSScrollingRecord.class.st
+++ b/DebuggingSpy/DSScrollingRecord.class.st
@@ -20,5 +20,6 @@ DSScrollingRecord >> eventName [
 { #category : 'actions api' }
 DSScrollingRecord >> record: aMorph [
 
-	toolName := aMorph asString
+	toolName := aMorph asString.
+	super record: aMorph window
 ]

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -149,6 +149,16 @@ DSSpyInstrumenter >> instrumentPrintIt [
 	SpCodePrintItCommand link: DSPrintItRecord link toAST: (SpCodePrintItCommand >> #execute) ast
 ]
 
+{ #category : 'interactions' }
+DSSpyInstrumenter >> instrumentScrolling [
+	"Instruments the scrolling in different components"
+
+	Morph link: DSScrollingRecord link toAST: (Morph >> #mouseWheel:) ast.
+	Morph link: DSScrollingRecord link toAST: (Morph >> #dragging:) ast.
+	GeneralScrollPaneMorph link: DSScrollingRecord link toAST: (GeneralScrollPaneMorph >> #mouseWheel:) ast
+	
+]
+
 { #category : 'system' }
 DSSpyInstrumenter >> instrumentSendersActions [
 	"Instruments actions to show senders of a method or class"
@@ -197,9 +207,6 @@ DSSpyInstrumenter >> instrumentSystem [
 DSSpyInstrumenter >> instrumentTabMorph [
 	"Instruments the active Tab Morph"
 
-	"ClyNotebookMorph link: DSMorphTabRecord link toAST: (ClyNotebookMorph >> #updateContentMorph:with:) ast.
-	SpNotebookMorph link: DSMorphTabRecord link toAST: (SpNotebookMorph >> #updateContentMorph:with:) ast"
-	
 	TabGroupMorph link: DSMorphTabRecord link toAST: (TabGroupMorph >> #update:with:) ast
 ]
 

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -207,9 +207,6 @@ DSSpyInstrumenter >> instrumentSystem [
 DSSpyInstrumenter >> instrumentTabMorph [
 	"Instruments the active Tab Morph"
 
-	"ClyNotebookMorph link: DSMorphTabRecord link toAST: (ClyNotebookMorph >> #updateContentMorph:with:) ast.
-	SpNotebookMorph link: DSMorphTabRecord link toAST: (SpNotebookMorph >> #updateContentMorph:with:) ast"
-	
 	TabGroupMorph link: DSMorphTabRecord link toAST: (TabGroupMorph >> #update:with:) ast
 ]
 

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -207,8 +207,10 @@ DSSpyInstrumenter >> instrumentSystem [
 DSSpyInstrumenter >> instrumentTabMorph [
 	"Instruments the active Tab Morph"
 
-	ClyNotebookMorph link: DSMorphTabRecord link toAST: (ClyNotebookMorph >> #updateContentMorph:with:) ast.
-	SpNotebookMorph link: DSMorphTabRecord link toAST: (SpNotebookMorph >> #updateContentMorph:with:) ast
+	"ClyNotebookMorph link: DSMorphTabRecord link toAST: (ClyNotebookMorph >> #updateContentMorph:with:) ast.
+	SpNotebookMorph link: DSMorphTabRecord link toAST: (SpNotebookMorph >> #updateContentMorph:with:) ast"
+	
+	TabGroupMorph link: DSMorphTabRecord link toAST: (TabGroupMorph >> #update:with:) ast
 ]
 
 { #category : 'debugpoints' }

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -207,7 +207,7 @@ DSSpyInstrumenter >> instrumentSystem [
 DSSpyInstrumenter >> instrumentTabMorph [
 	"Instruments the active Tab Morph"
 
-	TabGroupMorph link: DSMorphTabRecord link toAST: (TabGroupMorph >> #update:with:) ast
+	TabSelectorMorph link: DSMorphTabRecord link toAST: (TabSelectorMorph >> #selectedIndex:) ast
 ]
 
 { #category : 'debugpoints' }

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -207,7 +207,8 @@ DSSpyInstrumenter >> instrumentSystem [
 DSSpyInstrumenter >> instrumentTabMorph [
 	"Instruments the active Tab Morph"
 
-	TabSelectorMorph link: DSMorphTabRecord link toAST: (TabSelectorMorph >> #selectedIndex:) ast
+	ClyNotebookMorph link: DSMorphTabRecord link toAST: (ClyNotebookMorph >> #updateContentMorph:with:) ast.
+	SpNotebookMorph link: DSMorphTabRecord link toAST: (SpNotebookMorph >> #updateContentMorph:with:) ast
 ]
 
 { #category : 'debugpoints' }

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -154,9 +154,8 @@ DSSpyInstrumenter >> instrumentScrolling [
 	"Instruments the scrolling in different components"
 
 	Morph link: DSScrollingRecord link toAST: (Morph >> #mouseWheel:) ast.
-	Morph link: DSScrollingRecord link toAST: (Morph >> #dragging:) ast.
+	SliderMorph link: DSScrollingRecord link toAST: (SliderMorph >> #dragging:) ast.
 	GeneralScrollPaneMorph link: DSScrollingRecord link toAST: (GeneralScrollPaneMorph >> #mouseWheel:) ast
-	
 ]
 
 { #category : 'system' }
@@ -286,7 +285,8 @@ DSSpyInstrumenter >> logMouseEvents [
 	"Instrument mouse events"
 
 	self instrumentMouseEnterWindow.
-	self instrumentMouseLeaveWindow
+	self instrumentMouseLeaveWindow.
+	self instrumentScrolling
 ]
 
 { #category : 'system-instrumentation' }

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -187,9 +187,17 @@ DSSpyInstrumenter >> instrumentSystem [
 	self logCodeInteractions.
 	self logBrowsingActions.
 	self logDebuggerActions.
+	self logClyBrowserActions.
 	
 	"Intruments exceptions"
 	self instrumentExceptionSignalling
+]
+
+{ #category : 'interactions' }
+DSSpyInstrumenter >> instrumentTabMorph [
+	"Instruments the active Tab Morph"
+
+	TabSelectorMorph link: DSMorphTabRecord link toAST: (TabSelectorMorph >> #selectedIndex:) ast
 ]
 
 { #category : 'debugpoints' }
@@ -235,6 +243,13 @@ DSSpyInstrumenter >> logClipboardActions [
 
 	self instrumentCopySelection.
 	self instrumentPaste
+]
+
+{ #category : 'system-instrumentation' }
+DSSpyInstrumenter >> logClyBrowserActions [
+	"Instrument actions link to the Browser UI : scrolling, change in tabs, ..."
+
+	self instrumentTabMorph 
 ]
 
 { #category : 'system-instrumentation' }

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -197,7 +197,8 @@ DSSpyInstrumenter >> instrumentSystem [
 DSSpyInstrumenter >> instrumentTabMorph [
 	"Instruments the active Tab Morph"
 
-	TabSelectorMorph link: DSMorphTabRecord link toAST: (TabSelectorMorph >> #selectedIndex:) ast
+	ClyNotebookMorph link: DSMorphTabRecord link toAST: (ClyNotebookMorph >> #updateContentMorph:with:) ast.
+	SpNotebookMorph link: DSMorphTabRecord link toAST: (SpNotebookMorph >> #updateContentMorph:with:) ast
 ]
 
 { #category : 'debugpoints' }

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -197,8 +197,10 @@ DSSpyInstrumenter >> instrumentSystem [
 DSSpyInstrumenter >> instrumentTabMorph [
 	"Instruments the active Tab Morph"
 
-	ClyNotebookMorph link: DSMorphTabRecord link toAST: (ClyNotebookMorph >> #updateContentMorph:with:) ast.
-	SpNotebookMorph link: DSMorphTabRecord link toAST: (SpNotebookMorph >> #updateContentMorph:with:) ast
+	"ClyNotebookMorph link: DSMorphTabRecord link toAST: (ClyNotebookMorph >> #updateContentMorph:with:) ast.
+	SpNotebookMorph link: DSMorphTabRecord link toAST: (SpNotebookMorph >> #updateContentMorph:with:) ast"
+	
+	TabGroupMorph link: DSMorphTabRecord link toAST: (TabGroupMorph >> #update:with:) ast
 ]
 
 { #category : 'debugpoints' }

--- a/DebuggingSpy/DSWindowEventRecord.class.st
+++ b/DebuggingSpy/DSWindowEventRecord.class.st
@@ -19,21 +19,11 @@ Class {
 DSWindowEventRecord >> record: aWindowEvent [
 
 	| tool |
-	self recordWindowIdFromEvent: aWindowEvent.
+	self windowId: aWindowEvent window identityHash.
 	self recordWindowNameFromEvent: aWindowEvent.
 	tool := DSSpy toolInWindow: aWindowEvent window.
 	tool ifNil: [ ^ self ].
-	toolInfo := DSToolInfo
-		            toolNamed: tool class name
-		            id: tool identityHash
-		            windowId: windowId
-]
-
-{ #category : 'recording' }
-DSWindowEventRecord >> recordWindowIdFromEvent: anEvent [
-	|win|
-	win := anEvent window.
-	windowId := win identityHash
+	toolInfo := DSToolInfo toolNamed: tool class name id: tool identityHash windowId: windowId
 ]
 
 { #category : 'recording' }


### PR DESCRIPTION
This pull request allows to record scrolling by moving the scroll bar or by using mouse wheel. 
Also it allows to record changes in tabMorph (= when you have tabs in a window and you're moving between them). 

For now, there is some minor issues:
- recording tab changes produce a lot of record when it comes to the browser (Calypso), but we didn't find another way to get tabs' data. 
- scrolling records may be important, but it seems to not pollute too much the list of records. If needed, it will be possible to merge/squash them into one or two events (building the history).