### PR TITLE
Fix bugs linked to records

### DIFF
--- a/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
+++ b/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
@@ -564,12 +564,13 @@ DSSpyInstrumenterTest >> testInstrumentProceed [
 
 	| debugger command record |
 	debugger := StDummyDebuggerPresenter new.
+	debugger open.
 	command := StProceedCommand forContext: debugger.
 	command execute.
 
-	self assert: self registry size equals: 1.
+	self assert: self registry size equals: 2.
 
-	record := self registry first.
+	record := self registry second.
 	self assert: record class identicalTo: DSProceedRecord
 ]
 
@@ -578,12 +579,13 @@ DSSpyInstrumenterTest >> testInstrumentRestart [
 
 	| debugger command record |
 	debugger := StDummyDebuggerPresenter new.
+	debugger open.
 	command := StRestartCommand forContext: debugger.
 	command execute.
 
-	self assert: self registry size equals: 1.
+	self assert: self registry size equals: 2.
 
-	record := self registry first.
+	record := self registry second.
 	self assert: record class identicalTo: DSRestartRecord
 ]
 
@@ -592,12 +594,13 @@ DSSpyInstrumenterTest >> testInstrumentReturn [
 
 	| debugger command record |
 	debugger := StDummyDebuggerPresenter new.
+	debugger open.
 	command := StReturnValueCommand forContext: debugger.
 	command execute.
 
-	self assert: self registry size equals: 1.
+	self assert: self registry size equals: 2.
 
-	record := self registry first.
+	record := self registry second.
 	self assert: record class identicalTo: DSReturnValue
 ]
 
@@ -705,12 +708,13 @@ DSSpyInstrumenterTest >> testInstrumentRunTo [
 
 	| debugger command record |
 	debugger := StDummyDebuggerPresenter new.
+	debugger open.
 	command := StRunToSelectionCommand forContext: debugger.
 	command execute.
 
-	self assert: self registry size equals: 1.
+	self assert: self registry size equals: 2.
 
-	record := self registry first.
+	record := self registry second.
 	self assert: record class identicalTo: DSRunToSelectionRecord
 ]
 
@@ -785,19 +789,27 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeDoIt [
 { #category : 'tests - interactions' }
 DSSpyInstrumenterTest >> testInstrumentSpCodeDoItAndGoForInspector [
 
-	| presenter record |
+	| presenter record model context |
 	presenter := StObjectContextPresenter basicNew.
-	presenter setModelBeforeInitialization: self stObjectContextModelMock.
-	[ presenter intializePresentersWithEvaluator ]
-		on: Error
-		do: [ "we just pass layout initialization errors as we do not care" ].
+
+	model := StInspectorModel on: StInspectorMockObject new.
+	context := StInspectionContext fromPragma: (StInspectorMockObject >> #inspectionMock1:) pragmas first.
+	context inspectedObject: model inspectedObject.
+	presenter setModelBeforeInitialization: (StObjectContextModel new
+			 inspection: model;
+			 inspectedObject: model inspectedObject;
+			 context: context;
+			 yourself).
+	presenter application: StPharoApplication new.
+	presenter initialize.
+	presenter open.
+
 	presenter evaluator text: '4+2'.
 	presenter evaluator selectionInterval: (1 to: 3).
-
 	presenter doEvaluateAndGo.
 
-	self assert: self registry size equals: 1.
-	record := self registry first.
+	self assert: self registry size equals: 2.
+	record := self registry second.
 
 	self assert: record class identicalTo: DSDoItAndGoRecord.
 	self assert: record selectedString equals: '4+2'
@@ -905,12 +917,13 @@ DSSpyInstrumenterTest >> testInstrumentStepInto [
 
 	| debugger command record |
 	debugger := StDummyDebuggerPresenter new.
+	debugger open.
 	command := StStepIntoCommand forContext: debugger.
 	command execute.
 
-	self assert: self registry size equals: 1.
+	self assert: self registry size equals: 2.
 
-	record := self registry first.
+	record := self registry second.
 	self assert: record class identicalTo: DSStepIntoRecord 
 ]
 
@@ -919,12 +932,13 @@ DSSpyInstrumenterTest >> testInstrumentStepOver [
 
 	| debugger command record |
 	debugger := StDummyDebuggerPresenter new.
+	debugger open.
 	command := StStepOverCommand forContext: debugger.
 	command execute.
 
-	self assert: self registry size equals: 1.
+	self assert: self registry size equals: 2.
 
-	record := self registry first.
+	record := self registry second.
 	self assert: record class identicalTo: DSStepOverRecord
 ]
 
@@ -933,12 +947,13 @@ DSSpyInstrumenterTest >> testInstrumentStepThrough [
 
 	| debugger command record |
 	debugger := StDummyDebuggerPresenter new.
+	debugger open.
 	command := StStepThroughCommand forContext: debugger.
 	command execute.
 
-	self assert: self registry size equals: 1.
+	self assert: self registry size equals: 2.
 
-	record := self registry first.
+	record := self registry second.
 	self assert: record class identicalTo: DSStepThroughRecord
 ]
 
@@ -1021,7 +1036,7 @@ DSSpyInstrumenterTest >> testLoggingInteractionsWithNoSourceCode [
 		DSDoItRecord.
 		DSPrintItRecord } do: [ :recordClass |
 			| record |
-			record := recordClass new record: 'test'.
+			record := recordClass new recordSelectedString: 'test'.
 			self assert: record selectedString equals: DSSpy recordSourceCodeDisabledErrorMessage ]
 ]
 

--- a/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
+++ b/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
@@ -724,7 +724,7 @@ DSSpyInstrumenterTest >> testInstrumentSendersAction [
 	self assert: self registry size equals: 2.
 
 	record := self registry first.
-	self assert: record class identicalTo: DSImplementorsRecord.
+	self assert: record class identicalTo: DSSendersRecord.
 	self assert: record windowId equals: nil
 ]
 
@@ -743,7 +743,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeBrowse [
 	record := self registry first.
 
 	self assert: record class identicalTo: DSBrowseRecord.
-	self assert: record windowId equals: codePresenter window identityHash
+	self assert: record windowId equals: codePresenter window window identityHash
 ]
 
 { #category : 'tests - interactions' }
@@ -839,7 +839,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeImplementors [
 
 	record := self registry first.
 	self assert: record class identicalTo: DSImplementorsRecord.
-	self assert: record windowId equals: codePresenter window identityHash.
+	self assert: record windowId equals: codePresenter window window identityHash.
 	
 	record := self registry second.
 	self assert: record class identicalTo: DSWindowOpenedRecord
@@ -894,7 +894,7 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeSenders [
 
 	record := self registry first.
 	self assert: record class identicalTo: DSSendersRecord.
-	self assert: record windowId equals: codePresenter window identityHash.
+	self assert: record windowId equals: codePresenter window window identityHash.
 	
 	record := self registry second.
 	self assert: record class identicalTo: DSWindowOpenedRecord

--- a/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
+++ b/DebuggingSpy-Tests/DSSpyInstrumenterTest.class.st
@@ -820,17 +820,21 @@ DSSpyInstrumenterTest >> testInstrumentSpCodeDoItAndGoForPlayground [
 
 	| presenter record |
 	presenter := StPlaygroundPagePresenter basicNew.
-	presenter forceDisableLoading.
+	presenter setModelBeforeInitialization: (StPlaygroundPage new
+			 timeToWait: 5 milliSeconds;
+			 baseDirectory: FileSystem memory;
+			 yourself).
 	presenter application: StPharoApplication new.
-	presenter initializePresenters.
-	presenter setModelBeforeInitialization: DSFakeTextEditor new.
+	presenter forceDisableLoading.
+	presenter initialize.
+	presenter open.
+
 	presenter text text: '4+2'.
 	presenter text selectionInterval: (1 to: 3).
-
 	presenter doEvaluateAndGo.
 
-	self assert: self registry size equals: 1.
-	record := self registry first.
+	self assert: self registry size equals: 2.
+	record := self registry second.
 
 	self assert: record class identicalTo: DSDoItAndGoRecord.
 	self assert: record selectedString equals: '4+2'

--- a/DebuggingSpy/DSAbstractDebuggerActionRecord.class.st
+++ b/DebuggingSpy/DSAbstractDebuggerActionRecord.class.st
@@ -8,3 +8,9 @@ Class {
 	#package : 'DebuggingSpy',
 	#tag : 'Records'
 }
+
+{ #category : 'actions api' }
+DSAbstractDebuggerActionRecord >> record: aWindow [
+
+	self windowId: aWindow context window window identityHash
+]

--- a/DebuggingSpy/DSCodeActionRecord.class.st
+++ b/DebuggingSpy/DSCodeActionRecord.class.st
@@ -16,11 +16,16 @@ Class {
 { #category : 'actions api' }
 DSCodeActionRecord >> record: anEditor [
 
-	selectedString := DSSpy recordSourceCode
-		                  ifTrue: [ anEditor recordSelectedString ]
-		                  ifFalse: [ DSSpy recordSourceCodeDisabledErrorMessage ].
-
+	self recordSelectedString: anEditor recordSelectedString.
 	self windowId: anEditor recordWindow identityHash
+]
+
+{ #category : 'accessing' }
+DSCodeActionRecord >> recordSelectedString: aString [
+
+	selectedString := DSSpy recordSourceCode
+		                  ifTrue: [ aString ]
+		                  ifFalse: [ DSSpy recordSourceCodeDisabledErrorMessage ]
 ]
 
 { #category : 'accessing' }

--- a/DebuggingSpy/DSCodeActionRecord.class.st
+++ b/DebuggingSpy/DSCodeActionRecord.class.st
@@ -20,7 +20,7 @@ DSCodeActionRecord >> record: anEditor [
 		                  ifTrue: [ anEditor recordSelectedString ]
 		                  ifFalse: [ DSSpy recordSourceCodeDisabledErrorMessage ].
 
-	self windowId: anEditor identityHash
+	self windowId: anEditor recordWindow identityHash
 ]
 
 { #category : 'accessing' }

--- a/DebuggingSpy/DSCodeActionRecord.class.st
+++ b/DebuggingSpy/DSCodeActionRecord.class.st
@@ -20,7 +20,7 @@ DSCodeActionRecord >> record: anEditor [
 		                  ifTrue: [ anEditor recordSelectedString ]
 		                  ifFalse: [ DSSpy recordSourceCodeDisabledErrorMessage ].
 
-	super record: anEditor
+	self windowId: anEditor identityHash
 ]
 
 { #category : 'accessing' }

--- a/DebuggingSpy/DSHaltHitRecord.class.st
+++ b/DebuggingSpy/DSHaltHitRecord.class.st
@@ -45,13 +45,13 @@ DSHaltHitRecord >> once: aBoolean [
 
 { #category : 'actions api' }
 DSHaltHitRecord >> record: anRBProgramNodeAndASelector [
+
 	once := false.
 	conditional := false.
 	super record: anRBProgramNodeAndASelector first.
 	selector := anRBProgramNodeAndASelector second.
-	selector = #once: ifTrue:[once := true].
-	selector = #haltIf: ifTrue:[conditional := true]
-	
+	selector = #once: ifTrue: [ once := true ].
+	selector = #haltIf: ifTrue: [ conditional := true ]
 ]
 
 { #category : 'accessing' }

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -107,9 +107,10 @@ DSSpyInstrumenter >> instrumentImplementorsActions [
 	"Instruments actions to show implementors of a method"
 
 	ClyShowMessageImplementorCommand link: DSImplementorsRecord link toAST: (ClyShowMessageImplementorCommand >> #execute) ast.
-	ClyTextEditor link: DSImplementorsRecord link toAST: (ClyTextEditor>>#implementorsOf:) ast.
+	ClyTextEditor link: DSImplementorsRecord link toAST: (ClyTextEditor >> #implementorsOf:) ast.
 	RubSmalltalkEditor link: DSImplementorsRecord link toAST: (RubSmalltalkEditor >> #implementorsOf:) ast.
-	SpBrowseImplementorsCommand link: DSImplementorsRecord link toAST: (SpBrowseImplementorsCommand >> #execute) ast
+	SpBrowseImplementorsCommand link: DSImplementorsRecord link toAST: (SpBrowseImplementorsCommand >> #execute) ast.
+	StImplementorsCommand link: DSImplementorsRecord link toAST: (StImplementorsCommand >> #execute) ast
 ]
 
 { #category : 'interactions' }
@@ -165,7 +166,8 @@ DSSpyInstrumenter >> instrumentSendersActions [
 	ClyShowMessageSenderCommand link: DSSendersRecord link toAST: (ClyShowMessageSenderCommand >> #execute) ast.
 	ClyTextEditor link: DSSendersRecord link toAST: (ClyTextEditor>>#sendersOf:) ast.
 	RubSmalltalkEditor link: DSSendersRecord link toAST: (RubSmalltalkEditor >> #sendersOf:) ast.
-	SpBrowseSendersCommand link: DSSendersRecord link toAST: (SpBrowseSendersCommand >> #execute) ast
+	SpBrowseSendersCommand link: DSSendersRecord link toAST: (SpBrowseSendersCommand >> #execute) ast.
+	StMessageSendersCommand link: DSSendersRecord link toAST: (StMessageSendersCommand >> #execute) ast
 ]
 
 { #category : 'debugger' }

--- a/DebuggingSpy/DSSpyInstrumenter.class.st
+++ b/DebuggingSpy/DSSpyInstrumenter.class.st
@@ -164,7 +164,7 @@ DSSpyInstrumenter >> instrumentSendersActions [
 
 	ClyShowMessageSenderCommand link: DSSendersRecord link toAST: (ClyShowMessageSenderCommand >> #execute) ast.
 	ClyTextEditor link: DSSendersRecord link toAST: (ClyTextEditor>>#sendersOf:) ast.
-	RubSmalltalkEditor link: DSImplementorsRecord link toAST: (RubSmalltalkEditor >> #sendersOf:) ast.
+	RubSmalltalkEditor link: DSSendersRecord link toAST: (RubSmalltalkEditor >> #sendersOf:) ast.
 	SpBrowseSendersCommand link: DSSendersRecord link toAST: (SpBrowseSendersCommand >> #execute) ast
 ]
 

--- a/DebuggingSpy/SpToolCommand.extension.st
+++ b/DebuggingSpy/SpToolCommand.extension.st
@@ -3,5 +3,5 @@ Extension { #name : 'SpToolCommand' }
 { #category : '*DebuggingSpy' }
 SpToolCommand >> recordWindow [
 
-	^ self context window
+	^ self context window window
 ]

--- a/DebuggingSpy/StCommand.extension.st
+++ b/DebuggingSpy/StCommand.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'StCommand' }
+
+{ #category : '*DebuggingSpy' }
+StCommand >> recordWindow [
+
+	^ self context window window
+]

--- a/DebuggingSpy/StPresenter.extension.st
+++ b/DebuggingSpy/StPresenter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'StPresenter' }
+
+{ #category : '*DebuggingSpy' }
+StPresenter >> recordWindow [
+
+	^ self window window
+]


### PR DESCRIPTION
Some bugs were fixed:

- Changing how to record window (to get the wanted window according to `DSMouseEventRecord` way of recording)
- Fix bugs
- other little changes

It is possible that I missed some existing bugs or introduce new ones, please report any bugs found.

By the way, I tried to test most of the instrumentation but for Rubric and Calypso it is too difficult. Also, new tools like `StMethodBrowser` aren't finished yet and have lacks of tests... As I didn't develop these tools, I can't waste time by understing them without documentation and without testing package.