### PR TITLE
feat: new tabs

### DIFF
--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -167,15 +167,18 @@ DSRecordBrowserPresenterTest >> testColorAssociations [
 	| associations |
 	associations := {
 		                ((Color fromHexString: '#1f48ff') -> 'Browser').
-		                ((Color fromHexString: '#ff0fef') -> 'Debug point browser').
+		                ((Color fromHexString: '#772980') -> 'Debug point browser').
 		                ((Color fromHexString: '#345e54') -> 'Epicea').
 		                ((Color fromHexString: '#00e5ff') -> 'Iceberg').
-		                ((Color fromHexString: '#ff8f1f') -> 'Critique browser').
+		                ((Color fromHexString: '#ff9100') -> 'Critique browser').
 		                ((Color fromHexString: '#ff2200') -> 'Debugger').
 		                ((Color fromHexString: '#fad314') -> 'Inspector').
 		                ((Color fromHexString: '#70B77E') -> 'Playground').
-		                ((Color fromHexString: '#292929') -> 'Rewriter') }.
+		                ((Color fromHexString: '#ffffff') -> 'Rewriter').
+		                ((Color fromHexString: '#ec45ff') -> 'Debugging Spy').
+		                ((Color fromHexString: '#b3b3b3') -> 'Unknown window') }.
 
+	self assert: associations size equals: DSRecordBrowserPresenter colorAssociations size.
 	self assert: (associations allSatisfy: [ :asso | DSRecordBrowserPresenter colorAssociations includes: asso ])
 ]
 
@@ -269,15 +272,6 @@ DSRecordBrowserPresenterTest >> testGetWindowFromRecord [
 
 	self assert: window events first uuid equals: record uuid.
 	self assert: window name equals: record windowId
-]
-
-{ #category : 'tests' }
-DSRecordBrowserPresenterTest >> testPrintAsFormattedTime [
-	self assert: (browser printAsFormattedTime: (Time
-		 hour: 1
-		 minute: 2
-		 second: 3
-		 nanoSecond: 123456789) asDateAndTime) equals: '01:02:03.123456789'
 ]
 
 { #category : 'tests' }

--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -265,18 +265,12 @@ DSRecordBrowserPresenterTest >> testGetWindowFromRecord [
 ]
 
 { #category : 'tests' }
-DSRecordBrowserPresenterTest >> testGetTableRowColorFor [
-
-	| association |
-	self recordsTablePresenter roots: {
-			(DSAbstractEventRecord new -> Color red).
-			(DSAbstractEventRecord new -> Color blue).
-			(DSAbstractEventRecord new -> Color green) }.
-	association := self recordsTablePresenter roots first.
-
-	self assert: (browser getTableRowColorFor: association) equals: association value.
-	self recordsTablePresenter selectItem: association.
-	self assert: (browser getTableRowColorFor: association) equals: association value darker
+DSRecordBrowserPresenterTest >> testPrintAsFormattedTime [
+	self assert: (browser printAsFormattedTime: (Time
+		 hour: 1
+		 minute: 2
+		 second: 3
+		 nanoSecond: 123456789) asDateAndTime) equals: '01:02:03.123456789'
 ]
 
 { #category : 'tests' }

--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -223,7 +223,8 @@ DSRecordBrowserPresenterTest >> testGetHistoryFrom [
 
 	| fileRef |
 	fileRef := self generateRecordsFile.
-	self assert: (browser getHistoryFrom: fileRef) class equals: DSRecordHistory
+	self assert: (browser getHistoryFrom: fileRef) class equals: DSRecordHistory.
+	self assert: (browser getHistoryFrom: nil) isNil
 ]
 
 { #category : 'tests' }
@@ -349,10 +350,10 @@ DSRecordBrowserPresenterTest >> testUpdateLastRecord [
 { #category : 'tests' }
 DSRecordBrowserPresenterTest >> testUpdateRecordsTable [
 
-	| fileRef presenterMock |
+	| fileRef |
 	fileRef := self generateRecordsFile.
-	presenterMock := MockObject new on: #selectedItem respond: fileRef.
-	browser updateRecordsTable: presenterMock.
+	browser selectedHistory: (browser getHistoryFrom: fileRef).
+	browser updateRecordsTable.
 
 	self assert: self recordsTablePresenter roots first key class equals: DSBrowseRecord.
 	self assert: (self recordsTablePresenter roots at: 2) key class equals: DSMouseEnterWindowRecord.
@@ -374,11 +375,11 @@ DSRecordBrowserPresenterTest >> testUpdateRecordsTableWhenAddingFile [
 { #category : 'tests' }
 DSRecordBrowserPresenterTest >> testUpdateWindowsPresenter [
 
-	| records fileRef presenterMock windows |
+	| records fileRef windows |
 	records := self getRecordExamples.
 	fileRef := self generateRecordsFileFor: records.
-	presenterMock := MockObject new on: #selectedItem respond: fileRef.
-	browser updateWindowsPresenter: presenterMock.
+	browser selectedHistory: (browser getHistoryFrom: fileRef).
+	browser updateWindowsPresenter.
 
 	windows := self windowsPresenter roots.
 	self assert: windows size equals: 4.

--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -262,6 +262,21 @@ DSRecordBrowserPresenterTest >> testGetWindowFromRecord [
 ]
 
 { #category : 'tests' }
+DSRecordBrowserPresenterTest >> testGetTableRowColorFor [
+
+	| association |
+	self recordsTablePresenter roots: {
+			(DSAbstractEventRecord new -> Color red).
+			(DSAbstractEventRecord new -> Color blue).
+			(DSAbstractEventRecord new -> Color green) }.
+	association := self recordsTablePresenter roots first.
+
+	self assert: (browser getTableRowColorFor: association) equals: association value.
+	self recordsTablePresenter selectItem: association.
+	self assert: (browser getTableRowColorFor: association) equals: association value darker
+]
+
+{ #category : 'tests' }
 DSRecordBrowserPresenterTest >> testRemoveFile [
 
 	| fileRef1 fileRef2 |

--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -91,6 +91,12 @@ DSRecordBrowserPresenterTest >> setUp [
 	browser := DSRecordBrowserPresenter new
 ]
 
+{ #category : 'helpers' }
+DSRecordBrowserPresenterTest >> statisticsPresenter [
+
+	^ browser presenterAt: #statisticsPresenter
+]
+
 { #category : 'running' }
 DSRecordBrowserPresenterTest >> tearDown [
 
@@ -370,6 +376,25 @@ DSRecordBrowserPresenterTest >> testUpdateRecordsTableWhenAddingFile [
 	self assert: (self recordsTablePresenter roots at: 2) key class equals: DSMouseEnterWindowRecord.
 	self assert: (self recordsTablePresenter roots at: 3) key class equals: DSMouseLeaveWindowRecord.
 	self assert: self recordsTablePresenter roots last key class equals: DSInspectItRecord
+]
+
+{ #category : 'tests' }
+DSRecordBrowserPresenterTest >> testUpdateStatisticsPresenter [
+
+	| children |
+	self assert: browser updateStatisticsPresenter equals: browser.
+
+	browser selectedHistory: (browser getHistoryFrom: self generateRecordsFile).
+	browser updateStatisticsPresenter.
+
+	children := self statisticsPresenter children.
+	self assert: children size equals: 5.
+
+	self assert: children keys first label equals: 'Amount of events: 4'.
+	self assert: children keys second label equals: 'Amount of windows: 4'.
+	self assert: children keys third label equals: 'Time taken: 00:00:03'.
+	self assert: children keys fourth label equals: 'Idle time: 00:00:00'.
+	self assert: children keys last label equals: 'Absolute time taken: 00:00:03'
 ]
 
 { #category : 'tests' }

--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -25,7 +25,6 @@ DSRecordBrowserPresenterTest >> generateRecordsFileFor: someRecords [
 	"Generates a file of records and returns its file reference."
 
 	| recordFileRef writeStream |
-	| recordFileRef writeStream |
 
 	recordFileRef := self temporaryDirectory / ('ds-spy-test-' , UUID new asString).
 	recordFileRef ensureCreateFile.
@@ -34,10 +33,8 @@ DSRecordBrowserPresenterTest >> generateRecordsFileFor: someRecords [
 	writeStream nextPut: $[.
 
 	someRecords doWithIndex: [ :record :index |
-	someRecords doWithIndex: [ :record :index |
 			writeStream nextPutAll: (STON toString: record).
 
-			index = someRecords size ifFalse: [
 			index = someRecords size ifFalse: [
 					writeStream nextPut: $,.
 					writeStream crlf ] ].

--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -381,8 +381,8 @@ DSRecordBrowserPresenterTest >> testUpdateStatisticsPresenter [
 	children := self statisticsPresenter children.
 	self assert: children size equals: 5.
 
-	self assert: children keys first label equals: 'Amount of events: 4'.
-	self assert: children keys second label equals: 'Amount of windows: 4'.
+	self assert: children keys first label equals: 'Number of events: 4'.
+	self assert: children keys second label equals: 'Number of windows: 4'.
 	self assert: children keys third label equals: 'Time taken: 00:00:03'.
 	self assert: children keys fourth label equals: 'Idle time: 00:00:00'.
 	self assert: children keys last label equals: 'Absolute time taken: 00:00:03'
@@ -403,20 +403,6 @@ DSRecordBrowserPresenterTest >> testUpdateWindowsPresenter [
 ]
 
 { #category : 'tests' }
-DSRecordBrowserPresenterTest >> testUpdateWindowsPresenter [
-
-	| records fileRef presenterMock windows |
-	records := self getRecordExamples.
-	fileRef := self generateRecordsFileFor: records.
-	presenterMock := MockObject new on: #selectedItem respond: fileRef.
-	browser updateWindowsPresenter: presenterMock.
-
-	windows := self windowsPresenter roots.
-	self assert: windows size equals: 4.
-	self assert: (windows allSatisfy: [ :window | window class = DSWindowRecord ])
-]
-
-{ #category : 'tests' }
 DSRecordBrowserPresenterTest >> testWindowColorFrom [
 
 	| record |
@@ -429,12 +415,6 @@ DSRecordBrowserPresenterTest >> testWindowColorFrom [
 DSRecordBrowserPresenterTest >> timelinePresenter [
 
 	^ browser presenterAt: #graphicTimeline 
-]
-
-{ #category : 'helpers' }
-DSRecordBrowserPresenterTest >> windowsPresenter [
-
-	^ browser presenterAt: #windowsPresenter
 ]
 
 { #category : 'helpers' }

--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -16,10 +16,15 @@ DSRecordBrowserPresenterTest >> filesPresenter [
 
 { #category : 'helpers' }
 DSRecordBrowserPresenterTest >> generateRecordsFile [
-	"Generates a file of records and returns its file reference."
 
-	| records recordFileRef writeStream |
-	records := self getRecordExamples.
+	^ self generateRecordsFileFor: self getRecordExamples
+]
+
+{ #category : 'helpers' }
+DSRecordBrowserPresenterTest >> generateRecordsFileFor: someRecords [
+	"Generates a file of random records and returns its file reference."
+
+	| recordFileRef writeStream |
 
 	recordFileRef := self temporaryDirectory / ('ds-spy-test-' , UUID new asString).
 	recordFileRef ensureCreateFile.
@@ -27,10 +32,10 @@ DSRecordBrowserPresenterTest >> generateRecordsFile [
 
 	writeStream nextPut: $[.
 
-	records doWithIndex: [ :record :index |
+	someRecords doWithIndex: [ :record :index |
 			writeStream nextPutAll: (STON toString: record).
 
-			index = records size ifFalse: [
+			index = someRecords size ifFalse: [
 					writeStream nextPut: $,.
 					writeStream crlf ] ].
 
@@ -355,6 +360,20 @@ DSRecordBrowserPresenterTest >> testUpdateRecordsTableWhenAddingFile [
 ]
 
 { #category : 'tests' }
+DSRecordBrowserPresenterTest >> testUpdateWindowsPresenter [
+
+	| records fileRef presenterMock windows |
+	records := self getRecordExamples.
+	fileRef := self generateRecordsFileFor: records.
+	presenterMock := MockObject new on: #selectedItem respond: fileRef.
+	browser updateWindowsPresenter: presenterMock.
+
+	windows := self windowsPresenter roots.
+	self assert: windows size equals: 4.
+	self assert: (windows allSatisfy: [ :window | window class = DSWindowRecord ])
+]
+
+{ #category : 'tests' }
 DSRecordBrowserPresenterTest >> testWindowColorFrom [
 
 	| record |
@@ -367,4 +386,10 @@ DSRecordBrowserPresenterTest >> testWindowColorFrom [
 DSRecordBrowserPresenterTest >> timelinePresenter [
 
 	^ browser presenterAt: #graphicTimeline 
+]
+
+{ #category : 'helpers' }
+DSRecordBrowserPresenterTest >> windowsPresenter [
+
+	^ browser presenterAt: #windowsPresenter
 ]

--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -22,8 +22,9 @@ DSRecordBrowserPresenterTest >> generateRecordsFile [
 
 { #category : 'helpers' }
 DSRecordBrowserPresenterTest >> generateRecordsFileFor: someRecords [
-	"Generates a file of random records and returns its file reference."
+	"Generates a file of records and returns its file reference."
 
+	| recordFileRef writeStream |
 	| recordFileRef writeStream |
 
 	recordFileRef := self temporaryDirectory / ('ds-spy-test-' , UUID new asString).
@@ -33,8 +34,10 @@ DSRecordBrowserPresenterTest >> generateRecordsFileFor: someRecords [
 	writeStream nextPut: $[.
 
 	someRecords doWithIndex: [ :record :index |
+	someRecords doWithIndex: [ :record :index |
 			writeStream nextPutAll: (STON toString: record).
 
+			index = someRecords size ifFalse: [
 			index = someRecords size ifFalse: [
 					writeStream nextPut: $,.
 					writeStream crlf ] ].
@@ -389,6 +392,20 @@ DSRecordBrowserPresenterTest >> testUpdateWindowsPresenter [
 ]
 
 { #category : 'tests' }
+DSRecordBrowserPresenterTest >> testUpdateWindowsPresenter [
+
+	| records fileRef presenterMock windows |
+	records := self getRecordExamples.
+	fileRef := self generateRecordsFileFor: records.
+	presenterMock := MockObject new on: #selectedItem respond: fileRef.
+	browser updateWindowsPresenter: presenterMock.
+
+	windows := self windowsPresenter roots.
+	self assert: windows size equals: 4.
+	self assert: (windows allSatisfy: [ :window | window class = DSWindowRecord ])
+]
+
+{ #category : 'tests' }
 DSRecordBrowserPresenterTest >> testWindowColorFrom [
 
 	| record |
@@ -401,6 +418,12 @@ DSRecordBrowserPresenterTest >> testWindowColorFrom [
 DSRecordBrowserPresenterTest >> timelinePresenter [
 
 	^ browser presenterAt: #graphicTimeline 
+]
+
+{ #category : 'helpers' }
+DSRecordBrowserPresenterTest >> windowsPresenter [
+
+	^ browser presenterAt: #windowsPresenter
 ]
 
 { #category : 'helpers' }

--- a/DebuggingSpy-Browser/DSAbstractEventRecord.extension.st
+++ b/DebuggingSpy-Browser/DSAbstractEventRecord.extension.st
@@ -17,8 +17,29 @@ DSAbstractEventRecord class >> getLeafSubClasses [
 ]
 
 { #category : '*DebuggingSpy-Browser' }
-DSAbstractEventRecord >> ifWindow: aValue ifRecord: anotherValue [
-	"If the object is a DSWindowRecord, returns aValue, and returns the other value otherwise."
+DSAbstractEventRecord >> printAsFormattedTime [
+	"Returns the specified date and time as a string of format hh:mm:ss.nnnnnnnnn"
 
-	^ anotherValue
+	^ (String new: 18 streamContents: [ :aStream | dateTime asTime print24: true showSeconds: true on: aStream ]) asText allBold
+]
+
+{ #category : '*DebuggingSpy-Browser' }
+DSAbstractEventRecord >> type [
+	"Returns the record's type to be displayed in the windows presenter."
+
+	^ self class name
+]
+
+{ #category : '*DebuggingSpy-Browser' }
+DSAbstractEventRecord >> window [
+	"Returns the record's window from the browser selected history."
+
+	^ DSRecordBrowserPresenter uniqueInstance getWindowFromRecord: self
+]
+
+{ #category : '*DebuggingSpy-Browser' }
+DSAbstractEventRecord >> windowColor [
+	"Returns the record's window color."
+
+	^ self window windowColor
 ]

--- a/DebuggingSpy-Browser/DSAbstractEventRecord.extension.st
+++ b/DebuggingSpy-Browser/DSAbstractEventRecord.extension.st
@@ -15,3 +15,10 @@ DSAbstractEventRecord class >> getLeafSubClasses [
 
 	^ classes
 ]
+
+{ #category : '*DebuggingSpy-Browser' }
+DSAbstractEventRecord >> ifWindow: aValue ifRecord: anotherValue [
+	"If the object is a DSWindowRecord, returns aValue, and returns the other value otherwise."
+
+	^ anotherValue
+]

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -148,7 +148,8 @@ DSRecordBrowserPresenter >> connectPresenters [
 	fileListPresenter whenSelectionChangedDo: [ :presenter |
 			selectedHistory := self getHistoryFrom: presenter selectedItem.
 			self updateRecordsTable.
-			self updateWindowsPresenter ].
+			self updateWindowsPresenter.
+			self updateStatisticsPresenter ].
 
 	recordsFilter whenChangedDo: [ self updateRecordsTable ]
 ]
@@ -239,7 +240,7 @@ DSRecordBrowserPresenter >> getTableRowColorFor: anAssociation [
 	"Returns the row's corresponding color depending of the table selected row."
 
 	anAssociation = recordsTablePresenter selectedItem
-		ifTrue: [ ^ anAssociation value darker ]
+		ifTrue: [ ^ anAssociation value muchDarker ]
 		ifFalse: [ ^ anAssociation value ]
 ]
 
@@ -247,9 +248,7 @@ DSRecordBrowserPresenter >> getTableRowColorFor: anAssociation [
 DSRecordBrowserPresenter >> getWindowFromRecord: aRecord [
 	"Returns the record's corresponding window record in the history."
 
-	| rawRecords |
-	rawRecords := DSSpy materialize: fileListPresenter selectedItem.
-	^ ((DSRecordHistory on: rawRecords) windows select: [ :window | window windowId = aRecord windowId ]) first
+	^ (selectedHistory windows select: [ :window | window windowId = aRecord windowId ]) first
 ]
 
 { #category : 'initialization' }
@@ -283,7 +282,7 @@ DSRecordBrowserPresenter >> listAddedFilesActions [
 					  iconName: #history;
 					  description: 'Inspect the record history';
 					  shortcutKey: $h meta;
-					  action: [ (self getHistoryFrom: fileListPresenter selectedItem) inspect ] ];
+					  action: [ selectedHistory inspect ] ];
 		  addActionWith: [ :anItem |
 				  anItem
 					  name: 'Remove';
@@ -432,12 +431,6 @@ DSRecordBrowserPresenter >> statisticsPresenter [
 	"Instanciates a new records table that displays data based on the selected file's records."
 
 	^ SpGridLayout new
-		  add: 'Amount of events:' atPoint: 1 @ 1;
-		  add: (self newText appendText: 'test') atPoint: 2 @ 1;
-		  add: 'Amount of windows:' atPoint: 1 @ 2;
-		  add: (self newText appendText: 'test') atPoint: 2 @ 2;
-		  add: 'Record duration:' atPoint: 1 @ 3;
-		  add: (self newText appendText: 'test') atPoint: 2 @ 3;
 		  beColumnNotHomogeneous;
 		  yourself
 ]
@@ -511,6 +504,20 @@ DSRecordBrowserPresenter >> updateRecordsTable [
 	recordsTablePresenter roots: recordColorAssociations
 ]
 
+{ #category : 'operations' }
+DSRecordBrowserPresenter >> updateStatisticsPresenter [
+	"Updates the different fields in the statistics presenter depending on the selected history."
+
+	| stats |
+	selectedHistory ifNil: [ ^ self ].
+	stats := {
+		         ('Amount of events: ' , selectedHistory records size asString).
+		         ('Amount of windows: ' , selectedHistory windows size asString).
+		         ('Time taken: ' , (Time fromSeconds: selectedHistory stopTime asSeconds - selectedHistory startTime asSeconds) print24) }.
+
+	stats doWithIndex: [ :stat :index | statisticsPresenter add: stat asPresenter atPoint: 1 @ index ]
+]
+
 { #category : 'layout' }
 DSRecordBrowserPresenter >> updateToolbar [
 
@@ -539,33 +546,42 @@ DSRecordBrowserPresenter >> windowTitle [
 
 { #category : 'layout' }
 DSRecordBrowserPresenter >> windowsPresenter [
-	"Instanciates a new records table that displays data based on the selected file's records."
+	"Instanciates a new table that displays the windows and their events as children. For each column, the manipulated object could be either a DSWindowRecord or a record that inherits from DSAbstractEventRecord."
 
 	^ self newTreeTable
 		  addColumn: (SpStringTableColumn new
+				   width: 4;
+				   beNotExpandable;
+				   evaluated: [ nil ];
+				   yourself);
+		  addColumn: (SpStringTableColumn new
+				   width: 16;
+				   beNotExpandable;
+				   displayBackgroundColor: [ :anItem |
+					   anItem ifWindow: anItem windowColor ifRecord: (self getWindowFromRecord: anItem) windowColor ];
+				   evaluated: [ nil ];
+				   yourself);
+		  addColumn: (SpStringTableColumn new
 				   title: 'Window / Event';
-				   evaluated: [ :anItem | anItem asString ];
+				   evaluated: [ :anItem |
+						   anItem
+							   ifWindow: (anItem asString asText
+									    addAttribute: TextBackgroundColor red;
+									    yourself)
+							   ifRecord: anItem asString ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Type';
-				   evaluated: [ :anItem |
-						   anItem class = DSWindowRecord
-							   ifTrue: [ anItem windowType ]
-							   ifFalse: [ anItem class name ] ];
+				   evaluated: [ :anItem | anItem ifWindow: anItem windowType ifRecord: anItem class name ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Nb of events / Time';
 				   evaluated: [ :anItem |
-						   anItem class = DSWindowRecord
-							   ifTrue: [ anItem events size asString , ' events' ]
-							   ifFalse: [ self printAsFormattedTime: anItem dateTime ] ];
+					   anItem ifWindow: anItem events size asString , ' events' ifRecord: (self printAsFormattedTime: anItem dateTime) ];
 				   yourself);
 		  beResizable;
 		  actions: self windowsPresenterActions;
-		  children: [ :item |
-				  item class = DSWindowRecord
-					  ifTrue: [ item events ]
-					  ifFalse: [ {  } ] ];
+		  children: [ :item | item ifWindow: item events ifRecord: {  } ];
 		  yourself
 ]
 

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -328,6 +328,7 @@ DSRecordBrowserPresenter >> recordsTable [
 		  addColumn: (SpStringTableColumn new
 				   displayBackgroundColor: [ :association | association key windowColor ];
 				   width: 4;
+				   beNotSortable;
 				   evaluated: [ :association | '' ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
@@ -549,11 +550,13 @@ DSRecordBrowserPresenter >> windowsPresenter [
 	^ self newTreeTable
 		  addColumn: (SpStringTableColumn new
 				   width: 4;
+				   beNotSortable;
 				   evaluated: [ :item | '' ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   width: 20;
 				   beNotExpandable;
+				   beNotSortable;
 				   displayBackgroundColor: [ :anItem | anItem windowColor ];
 				   evaluated: [ :item | '' ];
 				   yourself);

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -507,8 +507,8 @@ DSRecordBrowserPresenter >> updateStatisticsPresenter [
 	| stats |
 	selectedHistory ifNil: [ ^ self ].
 	stats := {
-		         ('Amount of events: ' , selectedHistory records size asString).
-		         ('Amount of windows: ' , selectedHistory windows size asString).
+		         ('Number of events: ' , selectedHistory records size asString).
+		         ('Number of windows: ' , selectedHistory windows size asString).
 		         ('Time taken: ' , (Time fromSeconds: selectedHistory timeTaken) print24).
 		         ('Idle time: ' , (Time fromSeconds: selectedHistory computeIdleTime) print24).
 		         ('Absolute time taken: ' , (Time fromSeconds: selectedHistory absoluteTimeTaken) print24) }.
@@ -525,7 +525,7 @@ DSRecordBrowserPresenter >> updateToolbar [
 
 { #category : 'operations' }
 DSRecordBrowserPresenter >> updateWindowsPresenter [
-	"Updates the windows presenter by setting its roots by using the files presenter selected item."
+	"Updates the windows presenter by setting its roots using the selected item from files presenter."
 
 	selectedHistory ifNil: [ windowsPresenter roots: {  } ] ifNotNil: [ windowsPresenter roots: selectedHistory windows ]
 ]

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -309,13 +309,6 @@ DSRecordBrowserPresenter >> openAddFileDialog [
 	newFiles ifNotNil: [ newFiles do: [ :file | self addFile: file asFileReference ] ]
 ]
 
-{ #category : 'printing' }
-DSRecordBrowserPresenter >> printAsFormattedTime: aDateAndTime [
-	"Returns the specified date and time as a string of format hh:mm:ss.nnnnnnnnn"
-
-	^ String new: 18 streamContents: [ :aStream | aDateAndTime asTime print24: true showSeconds: true on: aStream ]
-]
-
 { #category : 'layout' }
 DSRecordBrowserPresenter >> recordsFilter [
 	"Instanciates a new chooser that displays every record classes that could be used to filter records in table."
@@ -343,7 +336,7 @@ DSRecordBrowserPresenter >> recordsTable [
 		  addColumn: (SpStringTableColumn new
 				   title: 'Time';
 				   displayBackgroundColor: [ :association | self getTableRowColorFor: association ];
-				   evaluated: [ :association | self printAsFormattedTime: association key dateTime ];
+				   evaluated: [ :association | association key printAsFormattedTime ];
 				   displayColor: [ :aRecord | Color white ];
 				   yourself);
 		  beResizable;
@@ -557,31 +550,27 @@ DSRecordBrowserPresenter >> windowsPresenter [
 		  addColumn: (SpStringTableColumn new
 				   width: 16;
 				   beNotExpandable;
-				   displayBackgroundColor: [ :anItem |
-					   anItem ifWindow: anItem windowColor ifRecord: (self getWindowFromRecord: anItem) windowColor ];
+				   displayBackgroundColor: [ :anItem | anItem windowColor ];
 				   evaluated: [ nil ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Window / Event';
-				   evaluated: [ :anItem |
-						   anItem
-							   ifWindow: (anItem asString asText
-									    addAttribute: TextBackgroundColor red;
-									    yourself)
-							   ifRecord: anItem asString ];
+				   evaluated: [ :anItem | anItem asString ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Type';
-				   evaluated: [ :anItem | anItem ifWindow: anItem windowType ifRecord: anItem class name ];
+				   evaluated: [ :anItem | anItem type ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
-				   title: 'Nb of events / Time';
-				   evaluated: [ :anItem |
-					   anItem ifWindow: anItem events size asString , ' events' ifRecord: (self printAsFormattedTime: anItem dateTime) ];
+				   title: 'Time';
+				   evaluated: [ :anItem | anItem printAsFormattedTime ];
 				   yourself);
 		  beResizable;
 		  actions: self windowsPresenterActions;
-		  children: [ :item | item ifWindow: item events ifRecord: {  } ];
+		  children: [ :item |
+				  item class = DSWindowRecord
+					  ifTrue: [ item events ]
+					  ifFalse: [ {  } ] ];
 		  yourself
 ]
 

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -149,7 +149,7 @@ DSRecordBrowserPresenter >> colorReferential [
 				   title: 'Window type';
 				   evaluated: [ :association | association value ];
 				   yourself);
-		  roots: self class colorAssociations;
+		  roots: (self class colorAssociations sort: [ :a :b | a key hue <= b key hue ]);
 		  beResizable;
 		  yourself
 ]
@@ -328,7 +328,6 @@ DSRecordBrowserPresenter >> recordsTable [
 		  addColumn: (SpStringTableColumn new
 				   displayBackgroundColor: [ :association | association key windowColor ];
 				   width: 4;
-				   beNotExpandable;
 				   evaluated: [ :association | '' ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
@@ -550,11 +549,10 @@ DSRecordBrowserPresenter >> windowsPresenter [
 	^ self newTreeTable
 		  addColumn: (SpStringTableColumn new
 				   width: 4;
-				   beNotExpandable;
 				   evaluated: [ :item | '' ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
-				   width: 16;
+				   width: 20;
 				   beNotExpandable;
 				   displayBackgroundColor: [ :anItem | anItem windowColor ];
 				   evaluated: [ :item | '' ];

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -249,15 +249,6 @@ DSRecordBrowserPresenter >> getRecordColorAssociationsFrom: aWindowRecordCollect
 ]
 
 { #category : 'helpers' }
-DSRecordBrowserPresenter >> getTableRowColorFor: anAssociation [
-	"Returns the row's corresponding color depending of the table selected row."
-
-	anAssociation = recordsTablePresenter selectedItem
-		ifTrue: [ ^ anAssociation value muchDarker ]
-		ifFalse: [ ^ anAssociation value ]
-]
-
-{ #category : 'helpers' }
 DSRecordBrowserPresenter >> getWindowFromRecord: aRecord [
 	"Returns the record's corresponding window record in the history."
 

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -16,7 +16,8 @@ Class {
 		'fileListPresenter',
 		'startRecordButtonPresenter',
 		'stopRecordButtonPresenter',
-		'windowsPresenter'
+		'windowsPresenter',
+		'statisticsPresenter'
 	],
 	#classInstVars : [
 		'uniqueInstance'
@@ -166,6 +167,7 @@ DSRecordBrowserPresenter >> defaultLayout [
 						    add: (SpTabLayout new
 								     add: recordsTablePresenter label: 'Records';
 								     add: windowsPresenter label: 'Windows';
+								     add: statisticsPresenter label: 'Statistics';
 								     yourself);
 						    yourself);
 				   yourself)
@@ -256,7 +258,8 @@ DSRecordBrowserPresenter >> initializePresenters [
 	fileListPresenter := self fileList.
 	recordsTablePresenter := self recordsTable.
 	recordsFilter := self recordsFilter.
-	windowsPresenter := self windowsPresenter
+	windowsPresenter := self windowsPresenter.
+	statisticsPresenter := self statisticsPresenter
 ]
 
 { #category : 'operations' }
@@ -407,6 +410,21 @@ DSRecordBrowserPresenter >> startRecording [
 	DSSpyInstrumenter instrumentSystem.
 	timerWindow startTimer.
 	self updateToolbar
+]
+
+{ #category : 'layout' }
+DSRecordBrowserPresenter >> statisticsPresenter [
+	"Instanciates a new records table that displays data based on the selected file's records."
+
+	^ SpGridLayout new
+		  add: 'Amount of events:' atPoint: 1 @ 1;
+		  add: (self newText appendText: 'test') atPoint: 2 @ 1;
+		  add: 'Amount of windows:' atPoint: 1 @ 2;
+		  add: (self newText appendText: 'test') atPoint: 2 @ 2;
+		  add: 'Record duration:' atPoint: 1 @ 3;
+		  add: (self newText appendText: 'test') atPoint: 2 @ 3;
+		  beColumnNotHomogeneous;
+		  yourself
 ]
 
 { #category : 'layout' }

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -17,7 +17,8 @@ Class {
 		'startRecordButtonPresenter',
 		'stopRecordButtonPresenter',
 		'windowsPresenter',
-		'statisticsPresenter'
+		'statisticsPresenter',
+		'selectedHistory'
 	],
 	#classInstVars : [
 		'uniqueInstance'
@@ -145,10 +146,11 @@ DSRecordBrowserPresenter >> connectPresenters [
 	"Updates the records and the timeline whenever the selected file is changed."
 
 	fileListPresenter whenSelectionChangedDo: [ :presenter |
-			self updateRecordsTable: presenter.
-			self updateWindowsPresenter: presenter ].
+			selectedHistory := self getHistoryFrom: presenter selectedItem.
+			self updateRecordsTable.
+			self updateWindowsPresenter ].
 
-	recordsFilter whenChangedDo: [ fileListPresenter selectedItem ifNotNil: [ self updateRecordsTable: fileListPresenter ] ]
+	recordsFilter whenChangedDo: [ self updateRecordsTable ]
 ]
 
 { #category : 'layout' }
@@ -214,6 +216,7 @@ DSRecordBrowserPresenter >> filterRecordsButton [
 DSRecordBrowserPresenter >> getHistoryFrom: aFileReference [
 	"Returns the generated history using the specified file reference which should countains DSSpy records."
 
+	aFileReference ifNil: [ ^ nil ].
 	^ DSRecordHistory on: (DSSpy materialize: aFileReference)
 ]
 
@@ -387,6 +390,18 @@ DSRecordBrowserPresenter >> removeFile: aFileReference [
 	fileListPresenter selectItem: (files ifNotEmpty: [ files last ])
 ]
 
+{ #category : 'accessing' }
+DSRecordBrowserPresenter >> selectedHistory [
+
+	^ selectedHistory
+]
+
+{ #category : 'accessing' }
+DSRecordBrowserPresenter >> selectedHistory: anHistory [
+
+	selectedHistory := anHistory
+]
+
 { #category : 'layout' }
 DSRecordBrowserPresenter >> startRecordButton [
 	"Instanciates a button that starts the DSSpy recording session on click."
@@ -482,19 +497,18 @@ DSRecordBrowserPresenter >> updateLastRecord: aRecord [
 ]
 
 { #category : 'operations' }
-DSRecordBrowserPresenter >> updateRecordsTable: filesPresenter [
+DSRecordBrowserPresenter >> updateRecordsTable [
 	"Updates the records' table presenter and add to each record its corresponding color."
 
-	| fileRef recordColorAssociations |
+	| recordColorAssociations |
 	recordColorAssociations := Array new.
-	fileRef := filesPresenter selectedItem.
 
-	fileRef ifNotNil: [
-			recordColorAssociations := self getRecordColorAssociationsFrom: (self getHistoryFrom: fileRef) windows.
+	selectedHistory ifNotNil: [
+			recordColorAssociations := self getRecordColorAssociationsFrom: selectedHistory windows.
 			recordColorAssociations := recordColorAssociations reject: [ :association |
 				                           recordsFilter chosenItems includes: association key class ] ].
 
-	recordsTablePresenter roots: recordColorAssociations 
+	recordsTablePresenter roots: recordColorAssociations
 ]
 
 { #category : 'layout' }
@@ -505,13 +519,10 @@ DSRecordBrowserPresenter >> updateToolbar [
 ]
 
 { #category : 'operations' }
-DSRecordBrowserPresenter >> updateWindowsPresenter: aFileListPresenter [
+DSRecordBrowserPresenter >> updateWindowsPresenter [
 	"Updates the windows presenter by setting its roots by using the files presenter selected item."
 
-	| fileRef |
-	fileRef := aFileListPresenter selectedItem.
-
-	fileRef ifNotNil: [ windowsPresenter roots: (self getHistoryFrom: fileRef) windows ]
+	selectedHistory ifNil: [ windowsPresenter roots: {  } ] ifNotNil: [ windowsPresenter roots: selectedHistory windows ]
 ]
 
 { #category : 'accessing' }

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -322,22 +322,22 @@ DSRecordBrowserPresenter >> recordsTable [
 
 	^ self newTreeTable
 		  addColumn: (SpStringTableColumn new
+				   displayBackgroundColor: [ :association | association key windowColor ];
+				   width: 4;
+				   beNotExpandable;
+				   evaluated: [ nil ];
+				   yourself);
+		  addColumn: (SpStringTableColumn new
 				   title: 'Event';
-				   displayBackgroundColor: [ :association | self getTableRowColorFor: association ];
 				   evaluated: [ :association | association key eventName asString ];
-				   displayColor: [ :aRecord | Color white ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Type';
-				   displayBackgroundColor: [ :association | self getTableRowColorFor: association ];
 				   evaluated: [ :association | association key class asString ];
-				   displayColor: [ :aRecord | Color white ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Time';
-				   displayBackgroundColor: [ :association | self getTableRowColorFor: association ];
 				   evaluated: [ :association | association key printAsFormattedTime ];
-				   displayColor: [ :aRecord | Color white ];
 				   yourself);
 		  beResizable;
 		  actions: self recordsTableActions;

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -230,6 +230,15 @@ DSRecordBrowserPresenter >> getRecordColorAssociationsFrom: aWindowRecordCollect
 ]
 
 { #category : 'helpers' }
+DSRecordBrowserPresenter >> getTableRowColorFor: anAssociation [
+	"Returns the row's corresponding color depending of the table selected row."
+
+	anAssociation = recordsTablePresenter selectedItem
+		ifTrue: [ ^ anAssociation value darker ]
+		ifFalse: [ ^ anAssociation value ]
+]
+
+{ #category : 'helpers' }
 DSRecordBrowserPresenter >> getTimelinePointsFrom: aHistory [
 	"Returns a list of plots for the timeline chart."
 
@@ -322,19 +331,19 @@ DSRecordBrowserPresenter >> recordsTable [
 	^ self newTreeTable
 		  addColumn: (SpStringTableColumn new
 				   title: 'Event';
-				   displayBackgroundColor: [ :association | association value ];
+				   displayBackgroundColor: [ :association | self getTableRowColorFor: association ];
 				   evaluated: [ :association | association key eventName asString ];
 				   displayColor: [ :aRecord | Color white ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Event type';
-				   displayBackgroundColor: [ :association | association value ];
+				   displayBackgroundColor: [ :association | self getTableRowColorFor: association ];
 				   evaluated: [ :association | association key class asString ];
 				   displayColor: [ :aRecord | Color white ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Time';
-				   displayBackgroundColor: [ :association | association value ];
+				   displayBackgroundColor: [ :association | self getTableRowColorFor: association ];
 				   evaluated: [ :association | association key dateTime asTime print24 ];
 				   displayColor: [ :aRecord | Color white ];
 				   yourself);

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -304,6 +304,13 @@ DSRecordBrowserPresenter >> openAddFileDialog [
 	newFiles ifNotNil: [ newFiles do: [ :file | self addFile: file asFileReference ] ]
 ]
 
+{ #category : 'printing' }
+DSRecordBrowserPresenter >> printAsFormattedTime: aDateAndTime [
+	"Returns the specified date and time as a string of format hh:mm:ss.nnnnnnnnn"
+
+	^ String new: 18 streamContents: [ :aStream | aDateAndTime asTime print24: true showSeconds: true on: aStream ]
+]
+
 { #category : 'layout' }
 DSRecordBrowserPresenter >> recordsFilter [
 	"Instanciates a new chooser that displays every record classes that could be used to filter records in table."
@@ -331,7 +338,7 @@ DSRecordBrowserPresenter >> recordsTable [
 		  addColumn: (SpStringTableColumn new
 				   title: 'Time';
 				   displayBackgroundColor: [ :association | self getTableRowColorFor: association ];
-				   evaluated: [ :association | association key dateTime asTime print24 ];
+				   evaluated: [ :association | self printAsFormattedTime: association key dateTime ];
 				   displayColor: [ :aRecord | Color white ];
 				   yourself);
 		  beResizable;
@@ -481,6 +488,7 @@ DSRecordBrowserPresenter >> updateToolbar [
 
 { #category : 'operations' }
 DSRecordBrowserPresenter >> updateWindowsPresenter: aFileListPresenter [
+	"Updates the windows presenter by setting its roots by using the files presenter selected item."
 
 	| fileRef |
 	fileRef := aFileListPresenter selectedItem.
@@ -521,12 +529,28 @@ DSRecordBrowserPresenter >> windowsPresenter [
 				   evaluated: [ :anItem |
 						   anItem class = DSWindowRecord
 							   ifTrue: [ anItem events size asString , ' events' ]
-							   ifFalse: [ anItem dateTime asTime print24 ] ];
+							   ifFalse: [ self printAsFormattedTime: anItem dateTime ] ];
 				   yourself);
 		  beResizable;
-		  "actions: self recordsTableActions;"children: [ :item |
-			  item class = DSWindowRecord
-				  ifTrue: [ item events ]
-				  ifFalse: [ {  } ] ];
+		  actions: self windowsPresenterActions;
+		  children: [ :item |
+				  item class = DSWindowRecord
+					  ifTrue: [ item events ]
+					  ifFalse: [ {  } ] ];
+		  yourself
+]
+
+{ #category : 'layout' }
+DSRecordBrowserPresenter >> windowsPresenterActions [
+	"Return a list of actions which can be done on a record from the table. For example, inspect the selected record."
+
+	^ SpActionGroup new
+		  addActionWith: [ :anItem |
+				  anItem
+					  name: 'Inspect';
+					  iconName: #inspect;
+					  description: 'Inspect the selected element.';
+					  shortcutKey: $i meta;
+					  action: [ windowsPresenter selectedItem key inspect ] ];
 		  yourself
 ]

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -39,7 +39,7 @@ DSRecordBrowserPresenter class >> colorAssociations [
 ]
 
 { #category : 'accessing' }
-DSRecordBrowserPresenter class >> defaultExtent [
+DSRecordBrowserPresenter class >> defaultPreferredExtent [
 
 	^ 1000 @ 600
 ]
@@ -74,6 +74,7 @@ DSRecordBrowserPresenter class >> resetBrowser [
 DSRecordBrowserPresenter class >> toggleBrowser [
 	"Opens the browser or closes it depending on its state. If it needs to be created, then creates and opens it."
 
+	<script>
 	uniqueInstance ifNotNil: [
 			uniqueInstance hasWindow ifTrue: [
 					^ uniqueInstance window isOpen
@@ -141,15 +142,14 @@ DSRecordBrowserPresenter >> colorReferential [
 	^ self newTreeTable
 		  addColumn: (SpStringTableColumn new
 				   title: 'Color';
-				   evaluated: [ ];
+				   evaluated: [ :association | '' ];
 				   displayBackgroundColor: [ :association | association key ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Window type';
 				   evaluated: [ :association | association value ];
-				   displayColor: [ :aRecord | Color white ];
 				   yourself);
-		  roots: (self class colorAssociations sort: [ :a :b | a key hue <= b key hue ]);
+		  roots: self class colorAssociations;
 		  beResizable;
 		  yourself
 ]
@@ -329,7 +329,7 @@ DSRecordBrowserPresenter >> recordsTable [
 				   displayBackgroundColor: [ :association | association key windowColor ];
 				   width: 4;
 				   beNotExpandable;
-				   evaluated: [ nil ];
+				   evaluated: [ :association | '' ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Event';
@@ -551,13 +551,13 @@ DSRecordBrowserPresenter >> windowsPresenter [
 		  addColumn: (SpStringTableColumn new
 				   width: 4;
 				   beNotExpandable;
-				   evaluated: [ nil ];
+				   evaluated: [ :item | '' ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   width: 16;
 				   beNotExpandable;
 				   displayBackgroundColor: [ :anItem | anItem windowColor ];
-				   evaluated: [ nil ];
+				   evaluated: [ :item | '' ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
 				   title: 'Window / Event';

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -11,7 +11,6 @@ Class {
 		'files',
 		'recordsTablePresenter',
 		'timerWindow',
-		'graphicTimeline',
 		'recordsFilter',
 		'toolbarPresenter',
 		'fileListPresenter',
@@ -146,7 +145,6 @@ DSRecordBrowserPresenter >> connectPresenters [
 
 	fileListPresenter whenSelectionChangedDo: [ :presenter |
 			self updateRecordsTable: presenter.
-			self updateTimelineChart.
 			self updateWindowsPresenter: presenter ].
 
 	recordsFilter whenChangedDo: [ fileListPresenter selectedItem ifNotNil: [ self updateRecordsTable: fileListPresenter ] ]
@@ -167,7 +165,6 @@ DSRecordBrowserPresenter >> defaultLayout [
 				   add: (SpBoxLayout newTopToBottom
 						    add: (SpTabLayout new
 								     add: recordsTablePresenter label: 'Records';
-								     add: graphicTimeline label: 'Timeline';
 								     add: windowsPresenter label: 'Windows';
 								     yourself);
 						    yourself);
@@ -242,19 +239,6 @@ DSRecordBrowserPresenter >> getTableRowColorFor: anAssociation [
 ]
 
 { #category : 'helpers' }
-DSRecordBrowserPresenter >> getTimelinePointsFrom: aHistory [
-	"Returns a list of plots for the timeline chart."
-
-	^ aHistory windows collectWithIndex: [ :windowRecord :index |
-			  RSTimeLinePlot new
-				  entries: {
-						  windowRecord events first dateTime asNanoSeconds.
-						  windowRecord events last dateTime asNanoSeconds }
-				  at: index;
-				  color: windowRecord windowColor ]
-]
-
-{ #category : 'helpers' }
 DSRecordBrowserPresenter >> getWindowFromRecord: aRecord [
 	"Returns the record's corresponding window record in the history."
 
@@ -271,7 +255,6 @@ DSRecordBrowserPresenter >> initializePresenters [
 	toolbarPresenter := self toolbar.
 	fileListPresenter := self fileList.
 	recordsTablePresenter := self recordsTable.
-	graphicTimeline := self newRoassal.
 	recordsFilter := self recordsFilter.
 	windowsPresenter := self windowsPresenter
 ]
@@ -352,7 +335,7 @@ DSRecordBrowserPresenter >> recordsTable [
 				   displayColor: [ :aRecord | Color white ];
 				   yourself);
 		  beResizable;
-		 " actions: self recordsTableActions;"
+		  actions: self recordsTableActions;
 		  yourself
 ]
 
@@ -442,34 +425,6 @@ DSRecordBrowserPresenter >> stopRecording [
 	timerWindow := nil
 ]
 
-{ #category : 'layout' }
-DSRecordBrowserPresenter >> timelineChart [
-	"Returns a chart that represents a timeline using the file list presenter's data for its plots."
-
-	| history names chart data |
-	fileListPresenter selectedItem ifNil: [ ^ nil ].
-
-	history := self getHistoryFrom: fileListPresenter selectedItem.
-	names := history windows collect: [ :i | i windowType ].
-
-	data := self getTimelinePointsFrom: history.
-	data size < 2 ifTrue: [ ^ nil ].
-
-	chart := RSCompositeChart new.
-	chart addAll: data.
-
-	chart verticalTick fromNames: names.
-
-	chart horizontalTick
-		useNiceLabel;
-		numberOfTicks: history windows size // 2;
-		useDiagonalLabel;
-		labelConversion: [ :v | (DateAndTime fromSeconds: v // 1000000000) asTime ]. "Plots are instancied using their dateTime as nano seconds to prevent events which last less than a second to be hided, so we convert them into seconds to get the label."
-
-	chart build.
-	^ chart
-]
-
 { #category : 'accessing' }
 DSRecordBrowserPresenter >> timerWindow [
 
@@ -515,18 +470,6 @@ DSRecordBrowserPresenter >> updateRecordsTable: filesPresenter [
 				                           recordsFilter chosenItems includes: association key class ] ].
 
 	recordsTablePresenter roots: recordColorAssociations 
-]
-
-{ #category : 'operations' }
-DSRecordBrowserPresenter >> updateTimelineChart [
-	"Regenerates the timeline chart using the selected record's data"
-
-	| chart |
-	chart := self timelineChart.
-	chart
-		ifNil: [ graphicTimeline script: [ :canvas |  ] ]
-		ifNotNil: [ graphicTimeline script: [ :canvas | chart renderIn: canvas ] ].
-	graphicTimeline refresh
 ]
 
 { #category : 'layout' }

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -107,7 +107,7 @@ DSRecordBrowserPresenter class >> windowColorFrom: anObject [
 { #category : 'accessing' }
 DSRecordBrowserPresenter class >> windowType [
 
-	^ 'Debugging Spy browser'
+	^ 'Debugging Spy'
 ]
 
 { #category : 'files' }

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -89,12 +89,25 @@ DSRecordBrowserPresenter class >> uniqueInstance [
 	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
+{ #category : 'windows' }
+DSRecordBrowserPresenter class >> windowColor [
+
+	<DSWindowColor>
+	^ Color fromHexString: '#ec45ff'
+]
+
 { #category : 'accessing' }
 DSRecordBrowserPresenter class >> windowColorFrom: anObject [
 	"If the specified object is nil, returns the default windowColor, else return its window color."
 
 	anObject ifNil: [ ^ self defaultWindowColor ].
 	^ anObject windowColor
+]
+
+{ #category : 'accessing' }
+DSRecordBrowserPresenter class >> windowType [
+
+	^ 'Debugging Spy browser'
 ]
 
 { #category : 'files' }
@@ -136,7 +149,7 @@ DSRecordBrowserPresenter >> colorReferential [
 				   evaluated: [ :association | association value ];
 				   displayColor: [ :aRecord | Color white ];
 				   yourself);
-		  roots: self class colorAssociations;
+		  roots: (self class colorAssociations sort: [ :a :b | a key hue <= b key hue ]);
 		  beResizable;
 		  yourself
 ]
@@ -506,7 +519,9 @@ DSRecordBrowserPresenter >> updateStatisticsPresenter [
 	stats := {
 		         ('Amount of events: ' , selectedHistory records size asString).
 		         ('Amount of windows: ' , selectedHistory windows size asString).
-		         ('Time taken: ' , (Time fromSeconds: selectedHistory stopTime asSeconds - selectedHistory startTime asSeconds) print24) }.
+		         ('Time taken: ' , (Time fromSeconds: selectedHistory timeTaken) print24).
+		         ('Idle time: ' , (Time fromSeconds: selectedHistory computeIdleTime) print24).
+		         ('Absolute time taken: ' , (Time fromSeconds: selectedHistory absoluteTimeTaken) print24) }.
 
 	stats doWithIndex: [ :stat :index | statisticsPresenter add: stat asPresenter atPoint: 1 @ index ]
 ]
@@ -585,6 +600,6 @@ DSRecordBrowserPresenter >> windowsPresenterActions [
 					  iconName: #inspect;
 					  description: 'Inspect the selected element.';
 					  shortcutKey: $i meta;
-					  action: [ windowsPresenter selectedItem key inspect ] ];
+					  action: [ windowsPresenter selectedItem inspect ] ];
 		  yourself
 ]

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -16,7 +16,8 @@ Class {
 		'toolbarPresenter',
 		'fileListPresenter',
 		'startRecordButtonPresenter',
-		'stopRecordButtonPresenter'
+		'stopRecordButtonPresenter',
+		'windowsPresenter'
 	],
 	#classInstVars : [
 		'uniqueInstance'
@@ -145,7 +146,8 @@ DSRecordBrowserPresenter >> connectPresenters [
 
 	fileListPresenter whenSelectionChangedDo: [ :presenter |
 			self updateRecordsTable: presenter.
-			self updateTimelineChart ].
+			self updateTimelineChart.
+			self updateWindowsPresenter: presenter ].
 
 	recordsFilter whenChangedDo: [ fileListPresenter selectedItem ifNotNil: [ self updateRecordsTable: fileListPresenter ] ]
 ]
@@ -166,6 +168,7 @@ DSRecordBrowserPresenter >> defaultLayout [
 						    add: (SpTabLayout new
 								     add: recordsTablePresenter label: 'Records';
 								     add: graphicTimeline label: 'Timeline';
+								     add: windowsPresenter label: 'Windows';
 								     yourself);
 						    yourself);
 				   yourself)
@@ -269,7 +272,8 @@ DSRecordBrowserPresenter >> initializePresenters [
 	fileListPresenter := self fileList.
 	recordsTablePresenter := self recordsTable.
 	graphicTimeline := self newRoassal.
-	recordsFilter := self recordsFilter
+	recordsFilter := self recordsFilter.
+	windowsPresenter := self windowsPresenter
 ]
 
 { #category : 'operations' }
@@ -336,7 +340,7 @@ DSRecordBrowserPresenter >> recordsTable [
 				   displayColor: [ :aRecord | Color white ];
 				   yourself);
 		  addColumn: (SpStringTableColumn new
-				   title: 'Event type';
+				   title: 'Type';
 				   displayBackgroundColor: [ :association | self getTableRowColorFor: association ];
 				   evaluated: [ :association | association key class asString ];
 				   displayColor: [ :aRecord | Color white ];
@@ -348,7 +352,7 @@ DSRecordBrowserPresenter >> recordsTable [
 				   displayColor: [ :aRecord | Color white ];
 				   yourself);
 		  beResizable;
-		  actions: self recordsTableActions;
+		 " actions: self recordsTableActions;"
 		  yourself
 ]
 
@@ -532,6 +536,15 @@ DSRecordBrowserPresenter >> updateToolbar [
 	stopRecordButtonPresenter enabled: DSSpy recordingSession
 ]
 
+{ #category : 'operations' }
+DSRecordBrowserPresenter >> updateWindowsPresenter: aFileListPresenter [
+
+	| fileRef |
+	fileRef := aFileListPresenter selectedItem.
+
+	fileRef ifNotNil: [ windowsPresenter roots: (self getHistoryFrom: fileRef) windows ]
+]
+
 { #category : 'accessing' }
 DSRecordBrowserPresenter >> windowIcon [
 
@@ -542,4 +555,35 @@ DSRecordBrowserPresenter >> windowIcon [
 DSRecordBrowserPresenter >> windowTitle [
 
 	^ 'Debugging record browser'
+]
+
+{ #category : 'layout' }
+DSRecordBrowserPresenter >> windowsPresenter [
+	"Instanciates a new records table that displays data based on the selected file's records."
+
+	^ self newTreeTable
+		  addColumn: (SpStringTableColumn new
+				   title: 'Window / Event';
+				   evaluated: [ :anItem | anItem asString ];
+				   yourself);
+		  addColumn: (SpStringTableColumn new
+				   title: 'Type';
+				   evaluated: [ :anItem |
+						   anItem class = DSWindowRecord
+							   ifTrue: [ anItem windowType ]
+							   ifFalse: [ anItem class name ] ];
+				   yourself);
+		  addColumn: (SpStringTableColumn new
+				   title: 'Nb of events / Time';
+				   evaluated: [ :anItem |
+						   anItem class = DSWindowRecord
+							   ifTrue: [ anItem events size asString , ' events' ]
+							   ifFalse: [ anItem dateTime asTime print24 ] ];
+				   yourself);
+		  beResizable;
+		  "actions: self recordsTableActions;"children: [ :item |
+			  item class = DSWindowRecord
+				  ifTrue: [ item events ]
+				  ifFalse: [ {  } ] ];
+		  yourself
 ]

--- a/DebuggingSpy-Browser/DSWindowRecord.extension.st
+++ b/DebuggingSpy-Browser/DSWindowRecord.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : 'DSWindowRecord' }
 
 { #category : '*DebuggingSpy-Browser' }
+DSWindowRecord >> ifWindow: aValue ifRecord: anotherValue [
+	"If the object is a DSWindowRecord, returns aValue, and returns the other value otherwise."
+
+	^ aValue
+]
+
+{ #category : '*DebuggingSpy-Browser' }
 DSWindowRecord >> windowColor [
 	"Returns the toolinfo associated window color, and the default color if undefined."
 

--- a/DebuggingSpy-Browser/DSWindowRecord.extension.st
+++ b/DebuggingSpy-Browser/DSWindowRecord.extension.st
@@ -15,12 +15,6 @@ DSWindowRecord >> type [
 ]
 
 { #category : '*DebuggingSpy-Browser' }
-DSWindowRecord >> window [
-
-	^ self
-]
-
-{ #category : '*DebuggingSpy-Browser' }
 DSWindowRecord >> windowColor [
 	"Returns the toolinfo associated window color, and the default color if undefined."
 

--- a/DebuggingSpy-Browser/DSWindowRecord.extension.st
+++ b/DebuggingSpy-Browser/DSWindowRecord.extension.st
@@ -1,10 +1,23 @@
 Extension { #name : 'DSWindowRecord' }
 
 { #category : '*DebuggingSpy-Browser' }
-DSWindowRecord >> ifWindow: aValue ifRecord: anotherValue [
-	"If the object is a DSWindowRecord, returns aValue, and returns the other value otherwise."
+DSWindowRecord >> printAsFormattedTime [
+	"Returns the formatted time to be displayed in the windows presenter."
 
-	^ aValue
+	^ nil
+]
+
+{ #category : '*DebuggingSpy-Browser' }
+DSWindowRecord >> type [
+	"Returns the window's type to be displayed in the windows presenter."
+
+	^ self windowType , ' (' , events size asString , ' events)'
+]
+
+{ #category : '*DebuggingSpy-Browser' }
+DSWindowRecord >> window [
+
+	^ self
 ]
 
 { #category : '*DebuggingSpy-Browser' }

--- a/DebuggingSpy-Browser/DebugPointBrowserPresenter.extension.st
+++ b/DebuggingSpy-Browser/DebugPointBrowserPresenter.extension.st
@@ -4,7 +4,7 @@ Extension { #name : 'DebugPointBrowserPresenter' }
 DebugPointBrowserPresenter class >> windowColor [
 
 	<DSWindowColor>
-	^ Color fromHexString: '#ff0fef'
+	^ Color fromHexString: '#772980'
 ]
 
 { #category : '*DebuggingSpy-Browser' }

--- a/DebuggingSpy-Browser/PharoShortcuts.extension.st
+++ b/DebuggingSpy-Browser/PharoShortcuts.extension.st
@@ -3,5 +3,5 @@ Extension { #name : 'PharoShortcuts' }
 { #category : '*DebuggingSpy-Browser' }
 PharoShortcuts >> openDebuggingSpyBrowserShortcut [
 
-	^ $d meta , $s meta
+	^ $o meta , $d meta
 ]

--- a/DebuggingSpy-Browser/StCritiquePackageSelectorPresenter.extension.st
+++ b/DebuggingSpy-Browser/StCritiquePackageSelectorPresenter.extension.st
@@ -4,7 +4,7 @@ Extension { #name : 'StCritiquePackageSelectorPresenter' }
 StCritiquePackageSelectorPresenter class >> windowColor [
 
 	<DSWindowColor>
-	^ Color fromHexString: '#ff8f1f'
+	^ Color fromHexString: '#ff9100'
 ]
 
 { #category : '*DebuggingSpy-Browser' }

--- a/DebuggingSpy-Browser/StRewriterExpressionFinderPresenter.extension.st
+++ b/DebuggingSpy-Browser/StRewriterExpressionFinderPresenter.extension.st
@@ -4,7 +4,7 @@ Extension { #name : 'StRewriterExpressionFinderPresenter' }
 StRewriterExpressionFinderPresenter class >> windowColor [
 
 	<DSWindowColor>
-	^ Color fromHexString: '#292929'
+	^ Color fromHexString: '#ffffff'
 ]
 
 { #category : '*DebuggingSpy-Browser' }

--- a/DebuggingSpy-Tests/DSRecordHistoryTest.class.st
+++ b/DebuggingSpy-Tests/DSRecordHistoryTest.class.st
@@ -44,7 +44,7 @@ DSRecordHistoryTest >> setUp [
 DSRecordHistoryTest >> testAbsoluteTimeTaken [
 
 	history records: self getRecordsExample.
-	self assert: history absoluteTimeTaken equals: 22
+	self assert: history absoluteTimeTaken equals: 22 * 60
 ]
 
 { #category : 'tests' }
@@ -372,6 +372,26 @@ DSRecordHistoryTest >> testCollectTimeDiscrepancies [
 	self assert: deltaDict third value equals: (Duration seconds: 16).
 	self assert: deltaDict third key first class equals: DSPrintItRecord.
 	self assert: deltaDict third key second class equals: DSClipboardCopyRecord
+]
+
+{ #category : 'tests' }
+DSRecordHistoryTest >> testComputeIdleTime [
+
+	| idleTime |
+	history records: {
+			(DSMouseEnterWindowRecord new dateTime: '2024-09-23T15:02:44' asDateAndTime).
+			(DSDoItRecord new dateTime: '2024-09-23T15:02:47' asDateAndTime).
+			(DSStepIntoRecord new dateTime: '2024-09-23T15:02:54' asDateAndTime).
+			(DSDebugItRecord new dateTime: '2024-09-23T15:02:56' asDateAndTime).
+			(DSMouseLeaveWindowRecord new dateTime: '2024-09-23T15:03:00' asDateAndTime).
+			(DSWindowClosedRecord new dateTime: '2024-09-23T15:03:03' asDateAndTime).
+			(DSMouseEnterWindowRecord new dateTime: '2024-09-23T15:06:07' asDateAndTime).
+			(DSPrintItRecord new dateTime: '2024-09-23T15:06:10' asDateAndTime).
+			(DSClipboardCopyRecord new dateTime: '2024-09-23T15:06:26' asDateAndTime).
+			(DSMethodRemovedRecord new dateTime: '2024-09-23T15:06:30' asDateAndTime) }.
+
+	idleTime := history computeIdleTime.
+	self assert: idleTime equals: 7 + 184 + 16
 ]
 
 { #category : 'tests' }
@@ -1124,6 +1144,24 @@ DSRecordHistoryTest >> testStopTime [
 
 	history records: self getRecordsExample.
 	self assert: history stopTime equals: '15:24:44' asTime
+]
+
+{ #category : 'tests' }
+DSRecordHistoryTest >> testTimeTaken [
+
+	history records: {
+			(DSMouseEnterWindowRecord new dateTime: '2024-09-23T15:02:44' asDateAndTime).
+			(DSDoItRecord new dateTime: '2024-09-23T15:02:47' asDateAndTime).
+			(DSStepIntoRecord new dateTime: '2024-09-23T15:02:54' asDateAndTime).
+			(DSDebugItRecord new dateTime: '2024-09-23T15:02:56' asDateAndTime).
+			(DSMouseLeaveWindowRecord new dateTime: '2024-09-23T15:03:00' asDateAndTime).
+			(DSWindowClosedRecord new dateTime: '2024-09-23T15:03:03' asDateAndTime).
+			(DSMouseEnterWindowRecord new dateTime: '2024-09-23T15:06:07' asDateAndTime).
+			(DSPrintItRecord new dateTime: '2024-09-23T15:06:10' asDateAndTime).
+			(DSClipboardCopyRecord new dateTime: '2024-09-23T15:06:26' asDateAndTime).
+			(DSMethodRemovedRecord new dateTime: '2024-09-23T15:06:30' asDateAndTime) }.
+
+	self assert: history timeTaken equals: 3 * 60 + 46 - (7 + 184 + 16)
 ]
 
 { #category : 'tests' }

--- a/DebuggingSpy-Tests/DSRecordHistoryTest.class.st
+++ b/DebuggingSpy-Tests/DSRecordHistoryTest.class.st
@@ -377,7 +377,12 @@ DSRecordHistoryTest >> testCollectTimeDiscrepancies [
 { #category : 'tests' }
 DSRecordHistoryTest >> testComputeIdleTime [
 
-	| idleTime |
+	history records: {
+			(DSMouseEnterWindowRecord new dateTime: '2024-09-23T15:02:44' asDateAndTime).
+			(DSDoItRecord new dateTime: '2024-09-23T15:02:47' asDateAndTime) }.
+
+	self assert: history computeIdleTime equals: 0.
+
 	history records: {
 			(DSMouseEnterWindowRecord new dateTime: '2024-09-23T15:02:44' asDateAndTime).
 			(DSDoItRecord new dateTime: '2024-09-23T15:02:47' asDateAndTime).
@@ -390,8 +395,7 @@ DSRecordHistoryTest >> testComputeIdleTime [
 			(DSClipboardCopyRecord new dateTime: '2024-09-23T15:06:26' asDateAndTime).
 			(DSMethodRemovedRecord new dateTime: '2024-09-23T15:06:30' asDateAndTime) }.
 
-	idleTime := history computeIdleTime.
-	self assert: idleTime equals: 7 + 184 + 16
+	self assert: history computeIdleTime equals: 7 + 184 + 16
 ]
 
 { #category : 'tests' }

--- a/DebuggingSpy/DSRecordHistory.class.st
+++ b/DebuggingSpy/DSRecordHistory.class.st
@@ -170,6 +170,7 @@ DSRecordHistory >> computeIdleTime [
 
 	| associations |
 	associations := self collectTimeDiscrepancies collect: [ :association | association value asSeconds ].
+	associations ifEmpty: [ ^ 0 ].
 	^ associations sum
 ]
 

--- a/DebuggingSpy/DSRecordHistory.class.st
+++ b/DebuggingSpy/DSRecordHistory.class.st
@@ -57,8 +57,7 @@ DSRecordHistory class >> windowLeaveEventTypes [
 DSRecordHistory >> absoluteTimeTaken [
 	"The absolute time taken to perform the recording of user events, including unmonitoring activities (interruptions or activities outside the IDE)."
 
-	^ ((records last dateTime asSeconds - records first dateTime asSeconds)
-	   / 60) asFloat
+	^ records last dateTime asSeconds - records first dateTime asSeconds
 ]
 
 { #category : 'API-history' }
@@ -163,6 +162,15 @@ DSRecordHistory >> collectTimeDiscrepancies [
 			previousRecord := record ].
 	
 	^ deltas
+]
+
+{ #category : 'API-history' }
+DSRecordHistory >> computeIdleTime [
+	"Returns the sum of all time discrepancies durations and returns the result as a number of seconds."
+
+	| associations |
+	associations := self collectTimeDiscrepancies collect: [ :association | association value asSeconds ].
+	^ associations sum
 ]
 
 { #category : 'API-history' }
@@ -609,8 +617,8 @@ DSRecordHistory >> timeTaken [
 	- last log minus the first log timestamp minus time gaps (or discrepancies)
 	- time gaps are calculated as the sum of time differences between two following events with a time delta > 5 min.
 	We consider that, if the user did not do anything (basically typing or moving the mouse) for more than 5 min, the she was away from the task."
-	^ ((records last dateTime asSeconds - records first dateTime asSeconds
-	   - self collectTimeDiscrepancies) / 60) asFloat
+
+	^ self absoluteTimeTaken - self computeIdleTime
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This PR permits to add two tabs for the windows and some general statistics.
The records and the windows tables do have a color indicator for window types, that enhancement permits them to be more readable.
I also added the Debugging Spy browser to the list of known windows as it should not be considered as other windows for the experiments.
<img width="1161" height="660" alt="Capture d’écran 2026-04-17 à 15 44 46" src="https://github.com/user-attachments/assets/28c53692-e5dc-4a60-b776-74e0bc3b77eb" />
<img width="1161" height="660" alt="Capture d’écran 2026-04-17 à 15 45 01" src="https://github.com/user-attachments/assets/c2c0f472-2377-4c17-a48d-dc15082b5c3b" />
<img width="1161" height="660" alt="Capture d’écran 2026-04-17 à 15 45 07" src="https://github.com/user-attachments/assets/fb0f6ef7-cfe5-44fd-978a-d9822333ea18" />

We also sort the colors in referential so its looks like this : 
<img width="1161" height="660" alt="Capture d’écran 2026-04-17 à 15 50 54" src="https://github.com/user-attachments/assets/1820cbd5-b81a-4299-b792-ef6d9206fed6" />

