### PR TITLE
refactor: DSRecordHistory >> #records -> #events (with accessors)

### DIFF
--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -194,7 +194,7 @@ DSRecordBrowserPresenterTest >> testFilteringAClassOfRecords [
 	history := browser getHistoryFrom: fileRef.
 
 	browser addFile: fileRef.
-	self assert: self recordsTablePresenter roots size equals: history records size.
+	self assert: self recordsTablePresenter roots size equals: history events size.
 
 	self recordsFilterPresenter sourceList selectItem: DSBrowseRecord.
 	self recordsFilterPresenter addSelected.

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -218,7 +218,7 @@ DSRecordBrowserPresenter >> fileListPresenterActions [
 					  iconName: #inspect;
 					  description: 'Inspect the raw records';
 					  shortcutKey: $i meta;
-					  action: [ selectedHistory records inspect ] ];
+					  action: [ selectedHistory events inspect ] ];
 		  addActionWith: [ :anItem |
 				  anItem
 					  name: 'Inspect history';
@@ -540,7 +540,7 @@ DSRecordBrowserPresenter >> updateStatisticsPresenter [
 	| stats |
 	selectedHistory ifNil: [ ^ self ].
 	stats := {
-		         ('Number of events: ' , selectedHistory records size asString).
+		         ('Number of events: ' , selectedHistory events size asString).
 		         ('Number of windows: ' , selectedHistory windows size asString).
 		         ('Time taken: ' , (Time fromSeconds: selectedHistory timeTaken) print24).
 		         ('Idle time: ' , (Time fromSeconds: selectedHistory computeIdleTime) print24).

--- a/DebuggingSpy-Tests/DSRecordHistoryTest.class.st
+++ b/DebuggingSpy-Tests/DSRecordHistoryTest.class.st
@@ -43,7 +43,7 @@ DSRecordHistoryTest >> setUp [
 { #category : 'tests' }
 DSRecordHistoryTest >> testAbsoluteTimeTaken [
 
-	history records: self getRecordsExample.
+	history events: self getRecordsExample.
 	self assert: history absoluteTimeTaken equals: 22 * 60
 ]
 
@@ -74,7 +74,7 @@ DSRecordHistoryTest >> testAddWindowRecord [
 DSRecordHistoryTest >> testAllRecordsOfKind [
 
 	| record |
-	history records: self getRecordsExample.
+	history events: self getRecordsExample.
 
 	self assert: (history allRecordsOfKind: DSMouseLeaveWindowRecord) size equals: 2.
 	record := (history allRecordsOfKind: DSMouseLeaveWindowRecord) first.
@@ -91,7 +91,7 @@ DSRecordHistoryTest >> testAllRecordsOfKind [
 DSRecordHistoryTest >> testBuildWindowHistory [
 
 	| windowsHistory listOfRecords |
-	history records: {
+	history events: {
 			DSDoItRecord new.
 			(DSWindowOpenedRecord new
 				 windowId: 1;
@@ -270,7 +270,7 @@ DSRecordHistoryTest >> testBuildWindows [
 				  (DSMouseEnterWindowRecord new windowId: -1).
 				  DSClipboardCopyRecord new.
 				  DSMouseLeaveWindowRecord new } asOrderedCollection) } as: IdentityDictionary).
-	history records: {
+	history events: {
 			DSDoItRecord new.
 			sourceDebugger.
 			DSClipboardCopyRecord new.
@@ -299,7 +299,7 @@ DSRecordHistoryTest >> testBuildWindows [
 DSRecordHistoryTest >> testCollectScrollingPeriods [
 
 	| scrollList |
-	history records: {
+	history events: {
 			(DSMouseEnterWindowRecord new
 				 dateTime: '2026-03-25T10:01:17' asDateAndTime;
 				 windowId: 1).
@@ -348,7 +348,7 @@ DSRecordHistoryTest >> testCollectScrollingPeriods [
 DSRecordHistoryTest >> testCollectTimeDiscrepancies [
 
 	| deltaDict |
-	history records: {
+	history events: {
 			(DSMouseEnterWindowRecord new dateTime: '2024-09-23T15:02:44' asDateAndTime).
 			(DSDoItRecord new dateTime: '2024-09-23T15:02:47' asDateAndTime).
 			(DSStepIntoRecord new dateTime: '2024-09-23T15:02:54' asDateAndTime).
@@ -377,13 +377,13 @@ DSRecordHistoryTest >> testCollectTimeDiscrepancies [
 { #category : 'tests' }
 DSRecordHistoryTest >> testComputeIdleTime [
 
-	history records: {
+	history events: {
 			(DSMouseEnterWindowRecord new dateTime: '2024-09-23T15:02:44' asDateAndTime).
 			(DSDoItRecord new dateTime: '2024-09-23T15:02:47' asDateAndTime) }.
 
 	self assert: history computeIdleTime equals: 0.
 
-	history records: {
+	history events: {
 			(DSMouseEnterWindowRecord new dateTime: '2024-09-23T15:02:44' asDateAndTime).
 			(DSDoItRecord new dateTime: '2024-09-23T15:02:47' asDateAndTime).
 			(DSStepIntoRecord new dateTime: '2024-09-23T15:02:54' asDateAndTime).
@@ -401,7 +401,7 @@ DSRecordHistoryTest >> testComputeIdleTime [
 { #category : 'tests' }
 DSRecordHistoryTest >> testCountDebugActions [
 
-	history records: {
+	history events: {
 			DSMouseEnterWindowRecord new.
 			DSMouseLeaveWindowRecord new.
 			DSDoItRecord new.
@@ -421,14 +421,14 @@ DSRecordHistoryTest >> testCountDebugActions [
 { #category : 'tests' }
 DSRecordHistoryTest >> testDateTime [
 
-	history records: self getRecordsExample.
+	history events: self getRecordsExample.
 	self assert: history dateTime equals: '2000-05-07T15:02:44' asDateAndTime
 ]
 
 { #category : 'tests' }
 DSRecordHistoryTest >> testDebugPointAdds [
 
-	history records: {
+	history events: {
 			(DSBreakDebugPointEventRecord new eventName: DebugPointAdded name).
 			DSMouseEnterWindowRecord new.
 			(DSBreakDebugPointEventRecord new eventName: DebugPointAdded name) } asOrderedCollection.
@@ -439,7 +439,7 @@ DSRecordHistoryTest >> testDebugPointAdds [
 DSRecordHistoryTest >> testDebugPointEvents [
 
 	| debugPointEvents |
-	history records: {
+	history events: {
 			(DSBreakDebugPointEventRecord new eventName: DebugPointHit name).
 			DSMouseEnterWindowRecord new.
 			(DSBreakDebugPointEventRecord new eventName: DebugPointAdded name) } asOrderedCollection.
@@ -457,7 +457,7 @@ DSRecordHistoryTest >> testDebugPointEvents [
 DSRecordHistoryTest >> testDebugPointEventsSelection [
 
 	| debugPointEvents |
-	history records: {
+	history events: {
 			(DSBreakDebugPointEventRecord new eventName: DebugPointHit name).
 			DSMouseEnterWindowRecord new.
 			(DSBreakDebugPointEventRecord new eventName: DebugPointAdded name). 
@@ -476,7 +476,7 @@ DSRecordHistoryTest >> testDebugPointEventsSelection [
 { #category : 'tests' }
 DSRecordHistoryTest >> testDebugPointHit [
 
-	history records: {
+	history events: {
 			(DSBreakDebugPointEventRecord new eventName: DebugPointHit name).
 			DSMouseEnterWindowRecord new.
 			(DSBreakDebugPointEventRecord new eventName: DebugPointAdded name) } asOrderedCollection.
@@ -486,7 +486,7 @@ DSRecordHistoryTest >> testDebugPointHit [
 { #category : 'tests' }
 DSRecordHistoryTest >> testDebugPointRemoved [
 
-	history records: {
+	history events: {
 			(DSBreakDebugPointEventRecord new eventName: DebugPointRemoved name).
 			DSMouseEnterWindowRecord new.
 			(DSBreakDebugPointEventRecord new eventName: DebugPointRemoved name) } asOrderedCollection.
@@ -496,7 +496,7 @@ DSRecordHistoryTest >> testDebugPointRemoved [
 { #category : 'tests' }
 DSRecordHistoryTest >> testDetectTimeDiscrepancies [
 
-	history records: self getRecordsExample.
+	history events: self getRecordsExample.
 	self assert: history detectTimeDiscrepancies equals: 1320.
 ]
 
@@ -560,7 +560,7 @@ DSRecordHistoryTest >> testEstimateSourceEventOfFrom [
 DSRecordHistoryTest >> testEventsAfter [
 
 	| listOfEvents |
-	history records: self getRecordsExample.
+	history events: self getRecordsExample.
 	listOfEvents := history eventsAfter: '2000-05-07T15:06:05' asDateAndTime.
 
 	self assert: listOfEvents size equals: 2.
@@ -572,7 +572,7 @@ DSRecordHistoryTest >> testEventsAfter [
 DSRecordHistoryTest >> testEventsBefore [
 
 	| listOfEvents |
-	history records: self getRecordsExample.
+	history events: self getRecordsExample.
 	listOfEvents := history eventsBefore: '2000-05-07T15:13:47' asDateAndTime.
 
 	self assert: listOfEvents size equals: 3.
@@ -584,7 +584,7 @@ DSRecordHistoryTest >> testEventsBefore [
 { #category : 'tests' }
 DSRecordHistoryTest >> testExecutedCode [
 
-	history records: {
+	history events: {
 			DSMouseEnterWindowRecord new.
 			DSDoItRecord new.
 			DSStepIntoRecord new.
@@ -664,7 +664,7 @@ DSRecordHistoryTest >> testFindWindowRecordKeyForID [
 { #category : 'tests' }
 DSRecordHistoryTest >> testFixMissingWindowIds [
 
-	history records: {
+	history events: {
 			DSDoItRecord new.
 			(DSMouseEnterWindowRecord new windowId: 1).
 			DSMethodAddedRecord new.
@@ -680,11 +680,11 @@ DSRecordHistoryTest >> testFixMissingWindowIds [
 
 	history fixMissingWindowIds.
 
-	self assert: history records first windowId equals: -1.
-	self assert: history records third windowId equals: 1.
-	self assert: (history records at: 6) windowId equals: -1.
-	self assert: (history records at: 8) windowId equals: 3.
-	self assert: (history records at: 10) windowId equals: -1.
+	self assert: history events first windowId equals: -1.
+	self assert: history events third windowId equals: 1.
+	self assert: (history events at: 6) windowId equals: -1.
+	self assert: (history events at: 8) windowId equals: 3.
+	self assert: (history events at: 10) windowId equals: -1.
 
 	self assert: history windowNames size equals: 1.
 	self assert: (history windowNames at: 3) equals: 'TestWindow'
@@ -715,7 +715,7 @@ DSRecordHistoryTest >> testFixWindowRecordKeysNames [
 DSRecordHistoryTest >> testGetSumOfScrollingPeriods [
 
 	| scrollList |
-	history records: {
+	history events: {
 			(DSMouseEnterWindowRecord new
 				 dateTime: '2026-03-25T10:01:17' asDateAndTime;
 				 windowId: 1).
@@ -765,7 +765,7 @@ DSRecordHistoryTest >> testGetSumOfScrollingPeriods [
 DSRecordHistoryTest >> testMergeContinuousEvents [
 
 	| newRecordList |
-	history records: {
+	history events: {
 			DSMouseEnterWindowRecord new.
 			DSMouseEnterWindowRecord new.
 			DSMethodAddedRecord new.
@@ -900,7 +900,7 @@ DSRecordHistoryTest >> testMergeFilteredWindowJumps [
 { #category : 'tests' }
 DSRecordHistoryTest >> testMethodsAdded [
 
-	history records: {
+	history events: {
 			DSMouseEnterWindowRecord new.
 			DSMethodAddedRecord new.
 			DSMethodRemovedRecord new.
@@ -912,7 +912,7 @@ DSRecordHistoryTest >> testMethodsAdded [
 { #category : 'tests' }
 DSRecordHistoryTest >> testMethodsModified [
 
-	history records: {
+	history events: {
 			DSMouseEnterWindowRecord new.
 			DSMethodAddedRecord new.
 			DSMethodModifiedRecord new.
@@ -927,7 +927,7 @@ DSRecordHistoryTest >> testMethodsModified [
 DSRecordHistoryTest >> testMethodsModifiedEvents [
 
 	| methodModifiedEvents |
-	history records: {
+	history events: {
 			DSMouseEnterWindowRecord new.
 			DSMethodAddedRecord new.
 			(DSMethodModifiedRecord new windowId: 23).
@@ -948,7 +948,7 @@ DSRecordHistoryTest >> testMethodsModifiedEvents [
 { #category : 'tests' }
 DSRecordHistoryTest >> testMethodsRemoved [
 
-	history records: {
+	history events: {
 			DSMouseEnterWindowRecord new.
 			DSMethodAddedRecord new.
 			DSMethodRemovedRecord new.
@@ -970,7 +970,7 @@ DSRecordHistoryTest >> testName [
 { #category : 'tests' }
 DSRecordHistoryTest >> testNumberOfSteps [
 
-	history records: {
+	history events: {
 			DSProceedRecord new.
 			DSMouseEnterWindowRecord new.
 			DSReturnValue new.
@@ -1025,7 +1025,7 @@ DSRecordHistoryTest >> testProcessRecords [
 
 	history processRecords: recordList.
 
-	self assert: history records size equals: 12.
+	self assert: history events size equals: 12.
 	self assert: history windows size equals: 3.
 	self assert: history windowsHistory size equals: 3.
 	self assert: history filteredWindows size equals: 3.
@@ -1054,7 +1054,7 @@ DSRecordHistoryTest >> testProcessRecordsOneWindow [
 
 	history processRecords: recordList.
 
-	self assert: history records size equals: 4.
+	self assert: history events size equals: 4.
 	self assert: history windows size equals: 1.
 	self assert: history windowsHistory size equals: 1.
 	self assert: history filteredWindows size equals: 1.
@@ -1087,7 +1087,7 @@ DSRecordHistoryTest >> testReconstructSourcesOfDebuggerOpenings [
 	sourceEvent1 := DSDebugItRecord new windowId: 1.
 	sourceEvent2 := DSPrintItRecord new windowId: 3.
 
-	history records: {
+	history events: {
 			DSDoItRecord new.
 			sourceEvent1.
 			DSStepIntoRecord new.
@@ -1118,7 +1118,7 @@ DSRecordHistoryTest >> testReconstructWindowsToolInfo [
 		                   windowIdentityHash: 1;
 		                   toolIdentityHash: 42.
 
-	history records: {
+	history events: {
 			(DSMouseEnterWindowRecord new toolInfo: toolInfoExample).
 			DSDebugItRecord new.
 			(DSMouseEnterWindowRecord new toolInfo: nil) }.
@@ -1139,21 +1139,21 @@ DSRecordHistoryTest >> testReconstructWindowsToolInfo [
 { #category : 'tests' }
 DSRecordHistoryTest >> testStartTime [
 
-	history records: self getRecordsExample.
+	history events: self getRecordsExample.
 	self assert: history startTime equals: '15:02:44' asTime
 ]
 
 { #category : 'tests' }
 DSRecordHistoryTest >> testStopTime [
 
-	history records: self getRecordsExample.
+	history events: self getRecordsExample.
 	self assert: history stopTime equals: '15:24:44' asTime
 ]
 
 { #category : 'tests' }
 DSRecordHistoryTest >> testTimeTaken [
 
-	history records: {
+	history events: {
 			(DSMouseEnterWindowRecord new dateTime: '2024-09-23T15:02:44' asDateAndTime).
 			(DSDoItRecord new dateTime: '2024-09-23T15:02:47' asDateAndTime).
 			(DSStepIntoRecord new dateTime: '2024-09-23T15:02:54' asDateAndTime).

--- a/DebuggingSpy/DSRecordHistory.class.st
+++ b/DebuggingSpy/DSRecordHistory.class.st
@@ -7,7 +7,6 @@ Class {
 	#instVars : [
 		'taskName',
 		'user',
-		'records',
 		'windowsHistory',
 		'tag',
 		'windowNames',
@@ -15,7 +14,8 @@ Class {
 		'windowJumps',
 		'filteredWindowJumps',
 		'filteredWindows',
-		'mergedWindowJumps'
+		'mergedWindowJumps',
+		'events'
 	],
 	#category : 'DebuggingSpy-Records-Extensions',
 	#package : 'DebuggingSpy',
@@ -57,7 +57,7 @@ DSRecordHistory class >> windowLeaveEventTypes [
 DSRecordHistory >> absoluteTimeTaken [
 	"The absolute time taken to perform the recording of user events, including unmonitoring activities (interruptions or activities outside the IDE)."
 
-	^ records last dateTime asSeconds - records first dateTime asSeconds
+	^ events last dateTime asSeconds - events first dateTime asSeconds
 ]
 
 { #category : 'API-history' }
@@ -71,7 +71,7 @@ DSRecordHistory >> addWindowRecord: aDSRecord [
 { #category : 'private - history' }
 DSRecordHistory >> allRecordsOfKind: aClass [
 
-	^ records select: [ :record | record isKindOf: aClass ]
+	^ events select: [ :record | record isKindOf: aClass ]
 ]
 
 { #category : 'API-history' }
@@ -79,7 +79,7 @@ DSRecordHistory >> buildWindowHistory [
 
 	self windowsHistory removeAll.
 	self fixMissingWindowIds.
-	records do: [ :r | self addWindowRecord: r ].
+	events do: [ :r | self addWindowRecord: r ].
 	self fixWindowRecordKeysNames
 ]
 
@@ -125,18 +125,18 @@ DSRecordHistory >> collectScrollingPeriods [
 	i := 1.
 	scrollingPeriods := OrderedCollection new.
 
-	[ i <= records size ] whileTrue: [
-			(records at: i) class = DSScrollingRecord ifTrue: [
+	[ i <= events size ] whileTrue: [
+			(events at: i) class = DSScrollingRecord ifTrue: [
 					| start stop |
-					start := (records at: i) dateTime.
-					stop := (records at: i) dateTime.
+					start := (events at: i) dateTime.
+					stop := (events at: i) dateTime.
 					i := i + 1.
-					[ i <= records size and: [ (records at: i) class = DSScrollingRecord ] ] whileTrue: [
-							stop := (records at: i) dateTime.
+					[ i <= events size and: [ (events at: i) class = DSScrollingRecord ] ] whileTrue: [
+							stop := (events at: i) dateTime.
 							i := i + 1 ].
 					scrollingPeriods add: {
 							start.
-							stop } -> (records at: i - 1) windowId ].
+							stop } -> (events at: i - 1) windowId ].
 			i := i + 1 ].
 
 	^ scrollingPeriods
@@ -147,7 +147,7 @@ DSRecordHistory >> collectTimeDiscrepancies [
 	"Returns a dictionary which contains all delta between two records above than 5s"
 
 	| time previousRecord copyOfRecords deltas |
-	copyOfRecords := records deepCopy.
+	copyOfRecords := events deepCopy.
 	time := 0.
 	deltas := OrderedCollection new.
 	previousRecord := copyOfRecords first.
@@ -184,7 +184,7 @@ DSRecordHistory >> countDebugActions [
 
 { #category : 'accessing' }
 DSRecordHistory >> dateTime [
-	^records first dateTime
+	^events first dateTime
 ]
 
 { #category : 'API-history' }
@@ -209,7 +209,7 @@ DSRecordHistory >> debugPointAnalysisMap [
 { #category : 'private - history' }
 DSRecordHistory >> debugPointEvents [
 
-	^ self records select: [ :r | (r isKindOf: DSAbstractDebugPointEventRecord)]
+	^ self events select: [ :r | (r isKindOf: DSAbstractDebugPointEventRecord)]
 ]
 
 { #category : 'private - history' }
@@ -237,8 +237,8 @@ DSRecordHistory >> detectTimeDiscrepancies [
 
 	| currentRecord totalDelta |
 	totalDelta := 0.
-	currentRecord := records first.
-	records do: [ :r |
+	currentRecord := events first.
+	events do: [ :r |
 			| delta |
 			((r isKindOf: DSWindowOpenedRecord) and: [ 'Finish task *' match: r windowName asString ]) ifTrue: [ ^ totalDelta ].
 			delta := r dateTime asSeconds - currentRecord dateTime asSeconds.
@@ -268,14 +268,26 @@ DSRecordHistory >> estimateSourceEventOf: aDSDebuggerOpeningRecord from: aRecord
 	^ aRecordList at: eventIndex - 1
 ]
 
+{ #category : 'accessing' }
+DSRecordHistory >> events [
+
+	^ events
+]
+
+{ #category : 'accessing' }
+DSRecordHistory >> events: anObject [
+
+	events := anObject
+]
+
 { #category : 'API-history' }
 DSRecordHistory >> eventsAfter: aDateAndTime [ 
-	^records select:[:e| e dateTime > aDateAndTime]
+	^events select:[:e| e dateTime > aDateAndTime]
 ]
 
 { #category : 'API-history' }
 DSRecordHistory >> eventsBefore: aDateAndTime [ 
-	^records select:[:e| e dateTime < aDateAndTime]
+	^events select:[:e| e dateTime < aDateAndTime]
 ]
 
 { #category : 'API-history' }
@@ -341,7 +353,7 @@ DSRecordHistory >> fixMissingWindowIds [
 	openedWindowStack := Stack new.
 	windowNames := Dictionary new.
 
-	records do: [ :r | 
+	events do: [ :r | 
 		r windowId ifNotNil: [ 
 			({ 
 				 DSWindowClosedRecord.
@@ -406,9 +418,9 @@ DSRecordHistory >> mergeContinuousEvents [
 	| newRecords merge record |
 	newRecords := OrderedCollection new.
 	merge := OrderedCollection new.
-	record := records first.
+	record := events first.
 	merge add: record.
-	(records copy asOrderedCollection
+	(events copy asOrderedCollection
 		 removeFirst;
 		 yourself) do: [ :next |
 			record class = next class ifFalse: [
@@ -493,13 +505,13 @@ DSRecordHistory >> processRecords: anArrayOfRecords [
 	"Build the history from an array of records"
 
 	"events with window id equals to 0 are automatic events triggered while opening a spec presenter while the window is not already open -> noise "
-	records := (anArrayOfRecords reject: [ :e | #( 0 ) includes: e windowId ]). 
+	events := (anArrayOfRecords reject: [ :e | #( 0 ) includes: e windowId ]). 
 	
 	"Transform raw events to model events"
 	(self allRecordsOfKind: DSAbstractDebugPointEventRecord) do: #asDebugPointRecord. 
 	
 	"Detect if we're in a specific task"
-	(records first isKindOf: DSStartTaskRecord) ifTrue: [ taskName := records first taskName ]. 
+	(events first isKindOf: DSStartTaskRecord) ifTrue: [ taskName := events first taskName ]. 
 	
 	"Windows"
 	self buildWindowHistory.
@@ -520,7 +532,7 @@ DSRecordHistory >> reconstructSourcesOfDebuggerOpenings [
 	sortedDebuggerWindows := (windows select: [ :w | w isDebugger ]) sort: [ :d1 :d2 |
 		                         d1 events first dateTime < d2 events first dateTime ].
 
-	recordsCopy := records copy asOrderedCollection.
+	recordsCopy := events copy asOrderedCollection.
 
 	sortedDebuggerWindows do: [ :w |
 			| sourceEvent |
@@ -535,7 +547,7 @@ DSRecordHistory >> reconstructWindowsToolInfo [
 	| toolInfos validWindows |
 	toolInfos := Dictionary new.
 
-	records do: [ :record |
+	events do: [ :record |
 			(record class = DSMouseEnterWindowRecord and: [ record toolInfo isNotNil ]) ifTrue: [
 				toolInfos at: record toolInfo windowIdentityHash ifAbsentPut: record toolInfo ] ].
 
@@ -551,21 +563,9 @@ DSRecordHistory >> reconstructWindowsToolInfo [
 					window toolInfo: (toolInfos at: id ifAbsent: [ nil ]) ] ].
 ]
 
-{ #category : 'accessing' }
-DSRecordHistory >> records [
-
-	^ records
-]
-
-{ #category : 'accessing' }
-DSRecordHistory >> records: anObject [
-
-	records := anObject
-]
-
 { #category : 'initialization' }
 DSRecordHistory >> reprocessRecords [
-	self processRecords: records asOrderedCollection 
+	self processRecords: events asOrderedCollection 
 ]
 
 { #category : 'private - history' }
@@ -579,12 +579,12 @@ DSRecordHistory >> secondarySourcesOfDebuggerOpenings [
 { #category : 'accessing' }
 DSRecordHistory >> startTime [
 
-	^ records first dateTime asTime
+	^ events first dateTime asTime
 ]
 
 { #category : 'accessing' }
 DSRecordHistory >> stopTime [
-	^records last dateTime asTime
+	^events last dateTime asTime
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
I propose to refactor this as some other classes use the name 'events' for their attributes so it would be uniformed.