### PR TITLE
fix: only display used record types in stats

### DIFF
--- a/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
+++ b/DebuggingSpy-Browser-Tests/DSRecordBrowserPresenterTest.class.st
@@ -235,11 +235,11 @@ DSRecordBrowserPresenterTest >> testGetNumberOfEventsPerType [
 				 (DSMouseLeaveWindowRecord new windowId: 1) }).
 
 	dict := browser getNumberOfEventsPerType.
-	self assert: dict keys size equals: DSAbstractEventRecord getLeafSubClasses size.
+	self assert: dict keys size equals: 3.
 	self assert: (dict at: DSMouseEnterWindowRecord) equals: 1.
 	self assert: (dict at: DSBrowseRecord) equals: 2.
 	self assert: (dict at: DSMouseLeaveWindowRecord) equals: 1.
-	self assert: (dict at: DSWindowOpenedRecord) equals: 0
+	self deny: (dict includesKey: DSWindowOpenedRecord)
 ]
 
 { #category : 'tests' }

--- a/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
+++ b/DebuggingSpy-Browser/DSRecordBrowserPresenter.class.st
@@ -342,9 +342,11 @@ DSRecordBrowserPresenter >> getNumberOfEventsPerType [
 
 	| dict |
 	dict := Dictionary new.
-	DSAbstractEventRecord getLeafSubClasses do: [ :recordClass | dict at: recordClass put: 0 ].
 	selectedHistory ifNotNil: [
-		selectedHistory events do: [ :record | dict at: record class update: [ :nbOfRecords | nbOfRecords + 1 ] ] ].
+			selectedHistory events do: [ :record |
+					(dict includesKey: record class)
+						ifTrue: [ dict at: record class update: [ :nbOfRecords | nbOfRecords + 1 ] ]
+						ifFalse: [ dict at: record class put: 1 ] ] ].
 	^ dict
 ]
 


### PR DESCRIPTION
The Debugging Spy statistics no longer show event types that are not present in the records.
<img width="1007" height="601" alt="Capture d’écran 2026-06-02 à 14 19 40" src="https://github.com/user-attachments/assets/513d0e83-dc82-4916-b7de-75b19f696929" />
